### PR TITLE
[PB] QoL improvements to runs directory structure

### DIFF
--- a/project/paperbench/README.md
+++ b/project/paperbench/README.md
@@ -182,7 +182,14 @@ In each run directory there is:
 - `run.log`: The log for that run.
 - `status.json`: The status of that run.
 - `metadata.json`: Metadata for that run.
-- `pb_result.json`: The grading result for that run.
+- `grade.json`: The grading result for that run.
+- A submissions directory, containing multiple timestamped submission directories (e.g., `2025-03-28T10-34-35-UTC`), each with:
+    - `log.json`: Logs from this submission attempt
+    - `submission.tar.gz`: The archived submission files
+    - If the submission was executed/graded, the directory may also contain:
+        - `submission_executed_grader_output_0.json`: Output from the grader.
+        - `submission_executed_metadata.json`: Metadata about the execution.
+        - `submission_executed.tar.gz`: The archived files after execution.
 
 Snapshots from the agent rollout are also stored in the run directory. An initial snapshot is created when the agent starts, and a final snapshot is created when the agent finishes. Intermediate snapshots are created throughout the agent rollout and can be set via `paperbench.solver.upload_interval_messages` or `paperbench.solver.upload_interval_seconds`.
 
@@ -190,21 +197,22 @@ Snapshots from the agent rollout are also stored in the run directory. An initia
 ```
 runs/
 ├── <run_group_id>/
+│   ├── group.log
 │   ├── <run_id>/
-│   │   ├── <inital_snapshot_metadata.json>
-│   │   ├── <inital_snapshot.tar.gz>
-│   │   ├── ...
-│   │   ├── ...
-│   │   ├── <final_snapshot_metadata.json>
-│   │   ├── <final_snapshot.tar.gz>
-│   │   ├── <final_snapshot>_repro.tar.gz>
-│   │   ├── <final_snapshot>_repro_grader_output_0.json
-│   │   ├── <final_snapshot>_repro_metadata.json
 │   │   ├── metadata.json
-│   │   ├── pb_result.json
+│   │   ├── grade.json
 │   │   ├── status.json
 │   │   └── run.log
-│   ├── group.log
+│   │   ├── submissions/
+│   │   │   ├── <timestamp-1>/
+│   │   │   │   ├── log.json
+│   │   │   │   └── submission.tar.gz
+│   │   │   └── <timestamp-2>/
+│   │   │       ├── log.json
+│   │   │       ├── submission.tar.gz
+│   │   │       ├── submission_executed_grader_output_0.json  # if graded
+│   │   │       ├── submission_executed_metadata.json  # if executed
+│   │   │       └── submission_executed.tar.gz  # if executed
 │   └── <other_run_ids>/...
 └── <other_run_group_ids>/...
 ```

--- a/project/paperbench/paperbench/utils.py
+++ b/project/paperbench/paperbench/utils.py
@@ -75,6 +75,12 @@ def get_experiments_dir() -> Path:
     return get_root().parent / "experiments"
 
 
+def get_dotenv() -> Path:
+    """Returns an absolute path to the .env file."""
+
+    return get_root().parent / ".env"
+
+
 def get_timestamp() -> str:
     """Returns the current timestamp in the format `YYYY-MM-DDTHH-MM-SS-Z`."""
 

--- a/project/paperbench/tests/integration/test_run_agent.py
+++ b/project/paperbench/tests/integration/test_run_agent.py
@@ -57,8 +57,6 @@ async def test_rollout(agent_id: str):
     perform reproduction or grading in this test.
     """
     with run_dir_ctx_manager() as runs_dir:
-        runs_dir = bf.join(runs_dir, uuid.uuid4().hex)
-
         solver = setup_solver(agent_id)
         judge_config = setup_judge_config()
         reproduction_config = setup_reproduction_config()
@@ -106,7 +104,6 @@ async def test_resuming():
     with run_dir_ctx_manager() as runs_dir:
         # Create a partially-completed run group, containing one "rice" run
         run_group_id = uuid.uuid4().hex
-        runs_dir = bf.join(runs_dir, run_group_id)
         run_id = create_run_id("rice")
         run_dir = create_run_dir(run_group_id, run_id, runs_dir)
         create_fake_submission(run_dir)
@@ -166,7 +163,6 @@ async def test_reproduction():
     with run_dir_ctx_manager() as runs_dir:
         # Create a partially-completed run group, containing one "rice" run
         run_group_id = uuid.uuid4().hex
-        runs_dir = bf.join(runs_dir, run_group_id)
         run_id = create_run_id("rice")
         run_dir = create_run_dir(run_group_id, run_id, runs_dir)
         create_fake_submission(run_dir)
@@ -276,7 +272,6 @@ async def test_grading(
     with run_dir_ctx_manager() as runs_dir:
         # Create a partially-completed run group, containing one "rice" run
         run_group_id = uuid.uuid4().hex
-        runs_dir = bf.join(runs_dir, run_group_id)
         run_id = create_run_id("rice")
         run_dir = create_run_dir(run_group_id, run_id, runs_dir)
         create_fake_submission(run_dir)
@@ -316,9 +311,8 @@ async def test_grading(
         paper_dir = bf.join(run_group_dir, paper_dirs[0])
 
         # Check grader output
-        grader_output_files = [
-            i for i in bf.listdir(paper_dir) if i.endswith("_grader_output_0.json")
-        ]
+        pattern = bf.join(paper_dir, "**/*.json")
+        grader_output_files = [i for i in bf.glob(pattern) if i.endswith("_grader_output_0.json")]
         assert (
             len(grader_output_files) == 1
         ), f"Expected one grader output file in {paper_dir}, found {len(grader_output_files)}"
@@ -335,6 +329,4 @@ async def test_grading(
         )  # Check graded task tree can be loaded
 
         # Check pb_result
-        assert bf.exists(
-            bf.join(paper_dir, "pb_result.json")
-        ), f"pb_result.json not found in {paper_dir}"
+        assert bf.exists(bf.join(paper_dir, "grade.json")), f"grade.json not found in {paper_dir}"

--- a/project/paperbench/tests/integration/utils.py
+++ b/project/paperbench/tests/integration/utils.py
@@ -60,17 +60,18 @@ def assert_rollout_files_exist(paper_dir: str, agent_id: str):
         bf.join(paper_dir, "metadata.json")
     ), f"metadata.json not found in paper directory at {paper_dir}"
 
-    tar_files = [i for i in bf.listdir(paper_dir) if i.endswith(".tar.gz")]
+    pattern = paper_dir + "/**/submission.tar.gz"
+    tar_files = list(bf.glob(pattern))
+
     assert (
         len(tar_files) >= 1
     ), f"Expected at least 1 tar.gz file in {paper_dir}, found {len(tar_files)}"
 
-    run_tar_files = sorted([f for f in tar_files if "repro" not in f])
+    run_tar_files = sorted([f for f in tar_files if "executed" not in f])
     assert (
         len(run_tar_files) >= 1
-    ), f"Expected at least one non-repro tar.gz file in {paper_dir}, found {len(run_tar_files)}"
-    tar_file = bf.join(paper_dir, run_tar_files[-1])  # Take the latest one (last in sorted order)
-    extracted_dir = tar_file.replace(".tar.gz", "")
+    ), f"Expected at least one non-executed tar.gz file in {paper_dir}, found {len(run_tar_files)}"
+    tar_file = run_tar_files[-1]  # Take the latest one (last in sorted order)
 
     # Extract the submission locally and check for expected files
     with tempfile.TemporaryDirectory() as tmp_submission_dir:


### PR DESCRIPTION
simplifies the runs directory structure to:

```
runs/
├── <run_group_id>/
│   ├── group.log
│   ├── <run_id>/
│   │   ├── metadata.json
│   │   ├── grade.json
│   │   ├── status.json
│   │   └── run.log
│   │   ├── submissions/
│   │   │   ├── <timestamp-1>/
│   │   │   │   ├── log.json
│   │   │   │   └── submission.tar.gz
│   │   │   └── <timestamp-2>/
│   │   │       ├── log.json
│   │   │       ├── submission.tar.gz
│   │   │       ├── submission_executed_grader_output_0.json  # if graded
│   │   │       ├── submission_executed_metadata.json  # if executed
│   │   │       └── submission_executed.tar.gz  # if executed
│   └── <other_run_ids>/...
└── <other_run_group_ids>/...
```