### PR TITLE
[PB] Release functionality for grading on files on computer

### DIFF
--- a/project/paperbench/paperbench/judge/utils.py
+++ b/project/paperbench/paperbench/judge/utils.py
@@ -1,7 +1,7 @@
 import os
 import re
 from pathlib import Path
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Generator
 
 import structlog.stdlib
 from drain3 import TemplateMiner
@@ -12,23 +12,27 @@ from paperbench.infra.alcatraz import (
     file_is_symlink_on_computer,
     get_mtime_on_computer,
     read_text_on_computer,
-    walk_dir_on_computer,
+    walk_dir_with_mtimes_on_computer,
 )
 
 logger = structlog.stdlib.get_logger(component=__name__)
 
+SIZE_LIMIT_BYTES = 200_000  # read at most 200 kB per file
 
-def safe_read_file(file_path: Path) -> str:
+
+def safe_read_file(file_path: Path, max_bytes: int | None = None) -> str:
     """
-    Try to read a file, with robustness to different encodings.
+    Try to read a file (up to max_bytes bytes), with robustness to different encodings.
     (Without this, we sometimes get `'utf-8' codec can't decode byte 0xa4 in position 64: invalid start byte`)
     """
     try:
         # Try utf-8 first
-        return file_path.read_text(encoding="utf-8")
+        with file_path.open(encoding="utf-8") as f:
+            return f.read(max_bytes)
     except UnicodeDecodeError:
         # Try latin1 if utf-8 fails
-        return file_path.read_text(encoding="latin1")
+        with file_path.open(encoding="latin1") as f:
+            return f.read(max_bytes)
 
 
 async def file_exists(file_path: Path, computer: ComputerInterface | None) -> bool:
@@ -39,7 +43,9 @@ async def file_exists(file_path: Path, computer: ComputerInterface | None) -> bo
 async def read_file_content(file_path: Path, computer: ComputerInterface | None) -> str:
     """Generic function to read the content of a file; on the computer or locally."""
     return (
-        await read_text_on_computer(computer, file_path) if computer else safe_read_file(file_path)
+        await read_text_on_computer(computer, file_path, SIZE_LIMIT_BYTES)
+        if computer
+        else safe_read_file(file_path, SIZE_LIMIT_BYTES)
     )
 
 
@@ -59,15 +65,32 @@ async def is_symlink(file_path: Path, computer: ComputerInterface | None) -> boo
     )
 
 
-async def walk_dir(
+def walk_dir_with_mtimes_locally(
+    dir_path: Path,
+) -> Generator[tuple[str, list[str], list[str], list[float]], None, None]:
+    """like os.walk, but also yields the mtimes of the files"""
+    for root, dirs, files in os.walk(dir_path):
+        mtimes = []
+        for f in files:
+            full_path = os.path.join(root, f)
+            try:
+                st = os.stat(full_path)
+                mtimes.append(st.st_mtime)
+            except OSError:
+                mtimes.append(0.0)
+        yield root, dirs, files, mtimes
+
+
+async def walk_dir_with_mtimes(
     dir_path: Path, computer: ComputerInterface | None
-) -> AsyncGenerator[tuple[str, list[str], list[str]], None]:
-    """Generic function for running equivalent of os.walk; on the computer or locally."""
+) -> AsyncGenerator[tuple[str, list[str], list[str], list[float]], None]:
+    """
+    Generic function for running equivalent of os.walk + mtimes; on the computer or locally."""
     if computer:
-        async for entry in walk_dir_on_computer(computer, dir_path):
+        async for entry in walk_dir_with_mtimes_on_computer(computer, dir_path):
             yield entry
     else:
-        for entry in os.walk(dir_path):
+        for entry in walk_dir_with_mtimes_locally(dir_path):
             yield entry
 
 

--- a/project/paperbench/paperbench/nano/eval.py
+++ b/project/paperbench/paperbench/nano/eval.py
@@ -665,7 +665,6 @@ class PaperBench(PythonCodingEval):
     def run_sanity_checks(self) -> None:
         self.check_for_docker()
         self.check_for_lfs()
-        self.check_for_computer_grading()
 
     def check_for_docker(self) -> None:
         if self.uses_local_config():
@@ -682,7 +681,3 @@ class PaperBench(PythonCodingEval):
         for paper in papers:
             with open(paper, "r") as f:
                 assert len(f.readlines()) > 5, f"Paper at {paper} should be pulled from git lfs"
-
-    def check_for_computer_grading(self) -> None:
-        if not self.judge.grade_locally:
-            raise NotImplementedError("Grading on computer is not fully supported yet.")

--- a/project/paperbench/tests/integration/test_run_agent.py
+++ b/project/paperbench/tests/integration/test_run_agent.py
@@ -259,17 +259,20 @@ async def test_reproduction() -> None:
 
 @pytest.mark.skipif(not is_docker_running(), reason="Docker is not running")
 @pytest.mark.parametrize(
-    "judge_scaffold",
+    "judge_scaffold, grade_locally",
     [
         pytest.param(
             judge_scaffold,
+            grade_locally,
             marks=(pytest.mark.skipif(in_ci(), reason="Not running grading tests in CI")),
         )
         for judge_scaffold in ("dummy", "simple")
+        for grade_locally in (True, False)
     ],
 )
 async def test_grading(
     judge_scaffold: str,
+    grade_locally: bool,
 ) -> None:
     """
     Test grading produces the expected output when using the dummy agent. We create a fake result of a rollout,
@@ -285,6 +288,8 @@ async def test_grading(
         solver = setup_solver("dummy")
         judge_config = setup_judge_config(
             skip_grading=False,
+            scaffold=judge_scaffold,
+            grade_locally=grade_locally,
         )
         reproduction_config = setup_reproduction_config()
         async with global_exit_stack:

--- a/project/paperbench/tests/integration/utils.py
+++ b/project/paperbench/tests/integration/utils.py
@@ -145,7 +145,11 @@ def setup_reproduction_config(skip_reproduction: bool = True) -> ReproductionCon
     )
 
 
-def setup_judge_config(skip_grading: bool = True, scaffold: str = "dummy") -> JudgeConfig:
+def setup_judge_config(
+    skip_grading: bool = True,
+    scaffold: str = "dummy",
+    grade_locally: bool = True,
+) -> JudgeConfig:
     image = "pb-env:latest"
     cluster_config = setup_cluster_config(image)
     return JudgeConfig(
@@ -153,6 +157,7 @@ def setup_judge_config(skip_grading: bool = True, scaffold: str = "dummy") -> Ju
         grade=not skip_grading,
         cluster_config=cluster_config,
         completer_config=OpenAITurnCompleter.Config(model="gpt-4o-mini"),  # cheap and quick
+        grade_locally=grade_locally,
     )
 
 

--- a/project/paperbench/tests/unit/test_computer.py
+++ b/project/paperbench/tests/unit/test_computer.py
@@ -8,8 +8,8 @@ from alcatraz.clusters.local import LocalConfig
 from nanoeval.solvers.computer_tasks.code_execution_interface import ComputerInterface
 from nanoeval_alcatraz.alcatraz_computer_interface import AlcatrazComputerInterface
 
-from paperbench.infra.alcatraz import copy_dir_to_computer
-from paperbench.judge.utils import walk_dir
+from paperbench.infra.alcatraz import copy_dir_to_computer, walk_dir_with_mtimes_on_computer
+from paperbench.judge.utils import walk_dir_with_mtimes, walk_dir_with_mtimes_locally
 
 
 @pytest.fixture(scope="function")
@@ -63,14 +63,13 @@ async def test_walk_dir_equivalence_with_copy(computer: ComputerInterface) -> No
         remote_base = "/tmp/test_dir"
         await copy_dir_to_computer(computer, local_base, remote_base)
 
-        local_walk = list(os.walk(local_base))
-        normalized_local = normalize_relative_walk(
-            [(str(root), dirs, files) for root, dirs, files in local_walk],
-            str(local_base),
-        )
+        local_walk = []
+        for root, dirs, files, _ in walk_dir_with_mtimes_locally(local_base):
+            local_walk.append((root, dirs, files))
+        normalized_local = normalize_relative_walk(local_walk, str(local_base))
 
         remote_walk = []
-        async for root, dirs, files in walk_dir(Path(remote_base), computer):
+        async for root, dirs, files, _ in walk_dir_with_mtimes(Path(remote_base), computer):
             remote_walk.append((root, dirs, files))
         normalized_remote = normalize_relative_walk(remote_walk, remote_base)
 
@@ -90,13 +89,13 @@ async def test_empty_directory(computer: ComputerInterface) -> None:
         remote_base = "/tmp/test_empty_dir"
         await copy_dir_to_computer(computer, local_base, remote_base)
 
-        local_walk = list(os.walk(local_base))
-        normalized_local = normalize_relative_walk(
-            [(str(root), dirs, files) for root, dirs, files in local_walk], str(local_base)
-        )
+        local_walk = []
+        for root, dirs, files, _ in walk_dir_with_mtimes_locally(local_base):
+            local_walk.append((root, dirs, files))
+        normalized_local = normalize_relative_walk(local_walk, str(local_base))
 
         remote_walk = []
-        async for root, dirs, files in walk_dir(Path(remote_base), computer):
+        async for root, dirs, files, _ in walk_dir_with_mtimes(Path(remote_base), computer):
             remote_walk.append((root, dirs, files))
         normalized_remote = normalize_relative_walk(remote_walk, remote_base)
 
@@ -121,13 +120,13 @@ async def test_hidden_files(computer: ComputerInterface) -> None:
         remote_base = "/tmp/test_hidden_files"
         await copy_dir_to_computer(computer, local_base, remote_base)
 
-        local_walk = list(os.walk(local_base))
-        normalized_local = normalize_relative_walk(
-            [(str(root), dirs, files) for root, dirs, files in local_walk], str(local_base)
-        )
+        local_walk = []
+        for root, dirs, files, _ in walk_dir_with_mtimes_locally(local_base):
+            local_walk.append((root, dirs, files))
+        normalized_local = normalize_relative_walk(local_walk, str(local_base))
 
         remote_walk = []
-        async for root, dirs, files in walk_dir(Path(remote_base), computer):
+        async for root, dirs, files, _ in walk_dir_with_mtimes(Path(remote_base), computer):
             remote_walk.append((root, dirs, files))
         normalized_remote = normalize_relative_walk(remote_walk, remote_base)
 
@@ -153,13 +152,13 @@ async def test_symlink(computer: ComputerInterface) -> None:
         remote_base = "/tmp/test_symlink"
         await copy_dir_to_computer(computer, local_base, remote_base)
 
-        local_walk = list(os.walk(local_base, followlinks=False))
-        normalized_local = normalize_relative_walk(
-            [(str(root), dirs, files) for root, dirs, files in local_walk], str(local_base)
-        )
+        local_walk = []
+        for root, dirs, files, _ in walk_dir_with_mtimes_locally(local_base):
+            local_walk.append((root, dirs, files))
+        normalized_local = normalize_relative_walk(local_walk, str(local_base))
 
         remote_walk = []
-        async for root, dirs, files in walk_dir(Path(remote_base), computer):
+        async for root, dirs, files, _ in walk_dir_with_mtimes(Path(remote_base), computer):
             remote_walk.append((root, dirs, files))
         normalized_remote = normalize_relative_walk(remote_walk, remote_base)
 
@@ -187,13 +186,13 @@ async def test_deep_nested_structure(computer: ComputerInterface) -> None:
         remote_base = "/tmp/test_deep_nested_structure"
         await copy_dir_to_computer(computer, local_base, remote_base)
 
-        local_walk = list(os.walk(local_base))
-        normalized_local = normalize_relative_walk(
-            [(str(root), dirs, files) for root, dirs, files in local_walk], str(local_base)
-        )
+        local_walk = []
+        for root, dirs, files, _ in walk_dir_with_mtimes_locally(local_base):
+            local_walk.append((root, dirs, files))
+        normalized_local = normalize_relative_walk(local_walk, str(local_base))
 
         remote_walk = []
-        async for root, dirs, files in walk_dir(Path(remote_base), computer):
+        async for root, dirs, files, _ in walk_dir_with_mtimes(Path(remote_base), computer):
             remote_walk.append((root, dirs, files))
         normalized_remote = normalize_relative_walk(remote_walk, remote_base)
 
@@ -222,13 +221,13 @@ async def test_special_characters_in_names(computer: ComputerInterface) -> None:
         remote_base = "/tmp/test_special_chars"
         await copy_dir_to_computer(computer, local_base, remote_base)
 
-        local_walk = list(os.walk(local_base))
-        normalized_local = normalize_relative_walk(
-            [(str(root), dirs, files) for root, dirs, files in local_walk], str(local_base)
-        )
+        local_walk = []
+        for root, dirs, files, _ in walk_dir_with_mtimes_locally(local_base):
+            local_walk.append((root, dirs, files))
+        normalized_local = normalize_relative_walk(local_walk, str(local_base))
 
         remote_walk = []
-        async for root, dirs, files in walk_dir(Path(remote_base), computer):
+        async for root, dirs, files, _ in walk_dir_with_mtimes(Path(remote_base), computer):
             remote_walk.append((root, dirs, files))
         normalized_remote = normalize_relative_walk(remote_walk, remote_base)
 
@@ -253,13 +252,13 @@ async def test_unicode_filenames(computer: ComputerInterface) -> None:
         remote_base = "/tmp/test_unicode"
         await copy_dir_to_computer(computer, local_base, remote_base)
 
-        local_walk = list(os.walk(local_base))
-        normalized_local = normalize_relative_walk(
-            [(str(root), dirs, files) for root, dirs, files in local_walk], str(local_base)
-        )
+        local_walk = []
+        for root, dirs, files, _ in walk_dir_with_mtimes_locally(local_base):
+            local_walk.append((root, dirs, files))
+        normalized_local = normalize_relative_walk(local_walk, str(local_base))
 
         remote_walk = []
-        async for root, dirs, files in walk_dir(Path(remote_base), computer):
+        async for root, dirs, files, _ in walk_dir_with_mtimes(Path(remote_base), computer):
             remote_walk.append((root, dirs, files))
         normalized_remote = normalize_relative_walk(remote_walk, remote_base)
 
@@ -287,13 +286,13 @@ async def test_broken_symlink(computer: ComputerInterface) -> None:
         remote_base = "/tmp/test_broken_symlink"
         await copy_dir_to_computer(computer, local_base, remote_base)
 
-        local_walk = list(os.walk(local_base, followlinks=False))
-        normalized_local = normalize_relative_walk(
-            [(str(root), dirs, files) for root, dirs, files in local_walk], str(local_base)
-        )
+        local_walk = []
+        for root, dirs, files, _ in walk_dir_with_mtimes_locally(local_base):
+            local_walk.append((root, dirs, files))
+        normalized_local = normalize_relative_walk(local_walk, str(local_base))
 
         remote_walk = []
-        async for root, dirs, files in walk_dir(Path(remote_base), computer):
+        async for root, dirs, files, _ in walk_dir_with_mtimes(Path(remote_base), computer):
             remote_walk.append((root, dirs, files))
         normalized_remote = normalize_relative_walk(remote_walk, remote_base)
 
@@ -336,16 +335,89 @@ async def test_mixed_content(computer: ComputerInterface) -> None:
         remote_base = "/tmp/test_mixed_content"
         await copy_dir_to_computer(computer, local_base, remote_base)
 
-        local_walk = list(os.walk(local_base, followlinks=False))
-        normalized_local = normalize_relative_walk(
-            [(str(root), dirs, files) for root, dirs, files in local_walk], str(local_base)
-        )
+        local_walk = []
+        for root, dirs, files, _ in walk_dir_with_mtimes_locally(local_base):
+            local_walk.append((root, dirs, files))
+        normalized_local = normalize_relative_walk(local_walk, str(local_base))
 
         remote_walk = []
-        async for root, dirs, files in walk_dir(Path(remote_base), computer):
+        async for root, dirs, files, _ in walk_dir_with_mtimes(Path(remote_base), computer):
             remote_walk.append((root, dirs, files))
         normalized_remote = normalize_relative_walk(remote_walk, remote_base)
 
         assert normalized_local == normalized_remote, (
             f"Mixed content test mismatch:\nLocal: {normalized_local}\nRemote: {normalized_remote}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_warn_if_exceeds_threshold(
+    computer: ComputerInterface, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """
+    Test that if the remote directory has more entries than `warn_threshold`,
+    we see a warning message in stdout.
+    """
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        local_base = Path(tmpdirname)
+        # Create 6 small files
+        for i in range(6):
+            (local_base / f"file_{i}.txt").write_text("content")
+
+        remote_base = "/tmp/test_warn_if_exceeds_threshold"
+        await copy_dir_to_computer(computer, local_base, remote_base)
+
+        # Use a small warn_threshold=5 so that 6 files triggers the warning
+        remote_walk = []
+        async for root, dirs, files, _ in walk_dir_with_mtimes_on_computer(
+            computer=computer, dir_path=Path(remote_base), warn_threshold=5
+        ):
+            remote_walk.append((root, dirs, files))
+
+        captured = capsys.readouterr()
+        assert "WARNING: Directory" in captured.out, (
+            f"Expected a warning when exceeding threshold, got:\n{captured.out}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_symlinked_directory(computer: ComputerInterface) -> None:
+    """
+    Test that a symlink pointing to a directory is reported just like os.walk:
+    it appears in the 'dirs' list and (by default) is not recursed into.
+    """
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        local_base = Path(tmpdirname) / "symlinked_dir_test"
+        local_base.mkdir()
+        # Create a real directory with one file inside
+        target_dir = local_base / "real_dir"
+        target_dir.mkdir()
+        (target_dir / "inner.txt").write_text("inside real dir")
+
+        # Create a symlink pointing to that directory
+        symlink_dir = local_base / "link_to_real"
+        relative_target = os.path.relpath(target_dir, symlink_dir.parent)
+        os.symlink(relative_target, symlink_dir, target_is_directory=True)
+
+        remote_base = "/tmp/test_symlinked_directory"
+        await copy_dir_to_computer(computer, local_base, remote_base)
+
+        # Collect local walk
+        local_walk = []
+        for root, dirs, files, _ in walk_dir_with_mtimes_locally(local_base):
+            local_walk.append((root, dirs, files))
+        normalized_local = normalize_relative_walk(local_walk, str(local_base))
+
+        # Collect remote walk
+        remote_walk = []
+        async for root, dirs, files, _ in walk_dir_with_mtimes_on_computer(
+            computer, Path(remote_base)
+        ):
+            remote_walk.append((root, dirs, files))
+        normalized_remote = normalize_relative_walk(remote_walk, remote_base)
+
+        # Check that both see "link_to_real" in dirs, not in files,
+        # and that they only recurse into real_dir, not into the symlink.
+        assert normalized_local == normalized_remote, (
+            f"Symlinked-directory mismatch:\nLocal: {normalized_local}\nRemote: {normalized_remote}"
         )


### PR DESCRIPTION
As discussed in #32, we had temporarily disabled grading files that lived on a computer.

This PR brings that functionality back, by focusing on speedups. 

It's still slower than grading locally, but seems acceptable to me. For reference, grading `rice` takes roughly 3 minutes locally and 12 minutes on the computer with `gpt-4o-mini`.