### PR TITLE
[PB] Integrate the monitor into PBTask.grade

### DIFF
--- a/project/paperbench/README.md
+++ b/project/paperbench/README.md
@@ -171,6 +171,7 @@ In each run directory there is:
 - `status.json`: The status of that run.
 - `metadata.json`: Metadata for that run.
 - `grade.json`: The grading result for that run.
+- `agent.log`: (optional) Rollout log from the solver. If present, the monitoring step will run and the run's grade will be marked with `"monitor_ran": true`.
 - A submissions directory, containing multiple timestamped submission directories (e.g., `2025-03-28T10-34-35-UTC`), each with:
     - `log.json`: Logs from this submission attempt
     - `submission.tar.gz`: The archived submission files
@@ -190,7 +191,8 @@ runs/
 │   │   ├── metadata.json
 │   │   ├── grade.json
 │   │   ├── status.json
-│   │   └── run.log
+│   │   ├── run.log
+│   │   ├── agent.log
 │   │   ├── submissions/
 │   │   │   ├── <timestamp-1>/
 │   │   │   │   ├── log.json

--- a/project/paperbench/paperbench/nano/eval.py
+++ b/project/paperbench/paperbench/nano/eval.py
@@ -194,6 +194,8 @@ class ExternalPythonCodingSolver(PythonCodingSolver):
                             resources_provided=task.judge.resources_provided,
                             judge_output=None,
                             reproduction_output=None,
+                            monitor_result=grade.paperbench_result.monitor_result,
+                            monitor_ran=grade.paperbench_result.monitor_ran,
                         ),
                         score=0.0,
                         grader_log="",

--- a/project/paperbench/paperbench/nano/structs.py
+++ b/project/paperbench/paperbench/nano/structs.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from dotenv import load_dotenv
 
+from paperbench.monitor.monitor import MonitorResult
+
 load_dotenv()
 import structlog.stdlib
 from alcatraz.clusters.local import LocalConfig
@@ -69,16 +71,22 @@ class PaperBenchResult:
     agent_output: AgentOutput | None = None
     judge_output: JudgeOutput | None = None
     reproduction_output: ReproductionOutput | None = None
+    monitor_result: MonitorResult | None = None
+    monitor_ran: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         data = {
             "paper_id": self.paper_id,
+            "run_id": self.run_id,
+            "submission_exists": self.submission_exists,
             "skipped_reproduction": self.skipped_reproduction,
             "code_only": self.code_only,
             "resources_provided": self.resources_provided,
             "agent_output": None,
             "judge_output": None,
             "reproduction_output": None,
+            "monitor_result": None,
+            "monitor_ran": self.monitor_ran,
         }
 
         if self.agent_output:
@@ -89,6 +97,9 @@ class PaperBenchResult:
 
         if self.reproduction_output:
             data["reproduction_output"] = self.reproduction_output.to_dict()
+
+        if self.monitor_result:
+            data["monitor_result"] = self.monitor_result.to_dict()
 
         return data
 

--- a/project/paperbench/paperbench/scripts/run_monitor.py
+++ b/project/paperbench/paperbench/scripts/run_monitor.py
@@ -78,7 +78,7 @@ async def monitor_single_log(
     )
 
     # Run monitor on the log file
-    result = await asyncio.to_thread(monitor.check_log, log_file)
+    result = await asyncio.to_thread(monitor.check_log, log_file.as_posix())
 
     return {
         "run_group_id": run_dir.parent.name,

--- a/project/paperbench/paperbench/solvers/dummy/solver.py
+++ b/project/paperbench/paperbench/solvers/dummy/solver.py
@@ -151,6 +151,11 @@ class PaperBenchDummySolver(PythonCodingSolver):
         with bf.BlobFile(bf.join(task.run_dir, "metadata.json"), "w") as f:
             json.dump(agent_output.to_dict(), f, indent=4)
 
+        with bf.BlobFile(bf.join(task.run_dir, "agent.log"), "w") as f:
+            f.write(
+                "This is a dummy agent that runs some basic debug commands and uploads the results.\n"
+            )
+
         return agent_output
 
     @asynccontextmanager


### PR DESCRIPTION
Previously, users were expected to separately run the monitor posthoc, and adjusting the scores manually. This PR makes it so that the monitor is integrated into the grading process.

1. We assume the solver produces an `agent.log` at the root of the run_dir (this is currently not the case for aisi basic agent but we are working on a PR to fix this. DummySolver supports this.)
2. If the agent.log is available, we run the monitor on it before running reproduce.sh, if not we dont run the monitor. We mark grades with `monitor_ran: bool` to keep track of this
3. If the monitor picks up violations, we exit early and assign a grade of 0 for that run