### PR TITLE
[PB] Cleanup reproduce flow

### DIFF
--- a/project/paperbench/paperbench/agents/registry.py
+++ b/project/paperbench/paperbench/agents/registry.py
@@ -108,3 +108,19 @@ class AgentRegistry:
 
 
 registry = AgentRegistry()
+
+
+def get_agents_env_vars(registry: AgentRegistry) -> dict[str, str]:
+    """Parses agent.env txt file of KEY=VALUE into a dictionary"""
+    agent_env_path = registry.get_agents_dir() / "agent.env"
+
+    if not agent_env_path.exists():
+        logger.warning(f"agent.env not found in {agent_env_path}")
+        return {}
+    env_vars = {}
+    with open(agent_env_path, "r") as f:
+        for line in f:
+            if line.strip() and not line.startswith("#"):
+                key, value = line.strip().split("=", 1)
+                env_vars[key] = value
+    return env_vars

--- a/project/paperbench/paperbench/nano/eval.py
+++ b/project/paperbench/paperbench/nano/eval.py
@@ -193,7 +193,7 @@ class ExternalPythonCodingSolver(PythonCodingSolver):
                             code_only=task.judge.code_only,
                             resources_provided=task.judge.resources_provided,
                             judge_output=None,
-                            reproduction_output=None,
+                            reproduction_metadata=None,
                             monitor_result=grade.paperbench_result.monitor_result,
                             monitor_ran=grade.paperbench_result.monitor_ran,
                         ),
@@ -569,11 +569,7 @@ class PaperBench(PythonCodingEval):
                 [r for r in results_clean if not r.agent_output or not r.submission_exists]
             ),
             "n_reproductions_failed": len(
-                [
-                    r
-                    for r in results_clean
-                    if not r.reproduction_output or not r.reproduction_output.success
-                ]
+                [r for r in results_clean if not r.reproduction_metadata]
             ),
             "n_gradings_failed": len(
                 [r for r in results_clean if not r.judge_output or not r.judge_output.success]
@@ -595,36 +591,32 @@ class PaperBench(PythonCodingEval):
         other_stats = {
             "repro_mean_time": safe_mean(
                 [
-                    r.reproduction_output.metadata.repro_execution_time  # type: ignore
+                    r.reproduction_metadata.repro_execution_time
                     for r in results_clean
-                    if r.reproduction_output and r.reproduction_output.success
+                    if r.reproduction_metadata and r.reproduction_metadata.repro_execution_time
                 ]
             ),
             "n_is_valid_git_repo": len(
                 [
                     r
                     for r in results_clean
-                    if r.reproduction_output
-                    and r.reproduction_output.success
-                    and r.reproduction_output.metadata.is_valid_git_repo  # type: ignore
+                    if r.reproduction_metadata and r.reproduction_metadata.is_valid_git_repo
                 ]
             ),
             "n_nontrivial_git_log": len(
                 [
                     r
                     for r in results_clean
-                    if r.reproduction_output
-                    and r.reproduction_output.success
-                    and len(r.reproduction_output.metadata.git_log.strip().splitlines()) > 1  # type: ignore
+                    if r.reproduction_metadata
+                    and r.reproduction_metadata.git_log is not None
+                    and len(r.reproduction_metadata.git_log.strip().splitlines()) > 1
                 ]
             ),
             "n_repro_script_exists": len(
                 [
                     r
                     for r in results_clean
-                    if r.reproduction_output
-                    and r.reproduction_output.success
-                    and r.reproduction_output.metadata.repro_script_exists  # type: ignore
+                    if r.reproduction_metadata and r.reproduction_metadata.repro_script_exists
                 ]
             ),
         }

--- a/project/paperbench/paperbench/reproducer.Dockerfile
+++ b/project/paperbench/paperbench/reproducer.Dockerfile
@@ -8,7 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y \
         software-properties-common \
-        wget curl unzip \
+        wget curl unzip sudo \
         build-essential git cmake \
         libatlas-base-dev libblas-dev liblapack-dev libopenblas-dev \
         gfortran libsm6 libxext6 libxrender-dev && \

--- a/project/paperbench/paperbench/scripts/alcatraz_services.py
+++ b/project/paperbench/paperbench/scripts/alcatraz_services.py
@@ -1,15 +1,14 @@
-import json
-import time
-from pathlib import Path
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator
 
-import blobfile as bf
 import structlog
+from alcatraz.clusters.local import ClusterConfig
 from dotenv import load_dotenv
 from nanoeval.solvers.computer_tasks.code_execution_interface import ComputerInterface
+from nanoeval_alcatraz.alcatraz_computer_interface import AlcatrazComputerInterface
 from structlog.stdlib import BoundLogger
 
-from paperbench.infra.alcatraz import put_file_in_computer, tar_and_extract_from_computer
-from paperbench.scripts.run_reproduce import reproduce
+from paperbench.infra.alcatraz import put_file_in_computer
 from paperbench.utils import find_dotenv
 
 logger = structlog.stdlib.get_logger(component=__name__)
@@ -50,76 +49,10 @@ async def put_submission_in_computer(
     logger.info(f"Files in /submission: {result.output.decode('utf-8')}")
 
 
-async def reproduce_on_computer(
-    computer: ComputerInterface,
-    submission_path: str,
-    logger: BoundLogger,
-    run_dir: str,
-    submission_cluster_path: Path = Path("/submission"),
-    output_cluster_path: Path = Path("/output"),
-    timeout: float | None = None,
-    retry_threshold: float = 0,
-) -> None:
-    """
-    Reproduce a single submission on a computer.
-
-    This script will spin up a pb-reproducer container on the computer to do the following:
-    - Download the submission
-    - Run the reproduction script
-    - Upload the reproduction results
-    """
-    time_start = time.time()
-    # TODO Don't override existing env vars if they're already set
-    # TODO verify the API keys passed to the solver are set
-
-    error_msg = None
-    try:
-        await computer.check_shell_command(
-            f"mkdir -p {output_cluster_path} {submission_cluster_path}"
-        )
-
-        # install prerequisites
-        cmd_str = "apt-get update && apt-get install -y git python3 curl sudo"
-        result = await computer.send_shell_command(cmd_str)
-        assert result.exit_code == 0, f"Install failed: {result}"
-
-        # Step 1: Put submission to /submission
-        await put_submission_in_computer(computer, submission_path, logger)
-
-        # Step 2: Kick off reproduction runner
-        repro_metadata = await reproduce(
-            computer=computer,
-            submission_path=submission_cluster_path,
-            logger=logger,
-            timeout=timeout,
-            retry_threshold=retry_threshold,
-        )
-
-        # Step 3: Save outputs
-        path_to_output = submission_path.replace(".tar.gz", "_executed_metadata.json")
-        bf.write_bytes(path_to_output, json.dumps(repro_metadata).encode("utf-8"))
-
-        # extract tar of the submission
-        timestamp = Path(submission_path).parts[-2]
-        upload_from = output_cluster_path / "submission_executed.tar.gz"
-        upload_to = bf.join(run_dir, "submissions", timestamp, "submission_executed.tar.gz")
-
-        await tar_and_extract_from_computer(
-            computer=computer,
-            dir_path_on_computer=submission_cluster_path,
-            tar_path_on_computer=upload_from,
-            tar_path_on_target=upload_to,
-            max_file_size="10M",
-            logger=logger,
-        )
-
-        logger.info(f"Reproduced dir has been written: {upload_to}")
-    except Exception as e:
-        error_msg = str(e)
-        logger.exception(f"Reproduction failed with error:\n{error_msg}")
-    finally:
-        time_end = time.time()
-        logger.info(f"Run completed in {time_end - time_start:.2f} seconds.")
-
-    time_end = time.time()
-    logger.info(f"Reproduction completed in {time_end - time_start:.2f} seconds.")
+@asynccontextmanager
+async def start_alcatraz_computer(
+    cluster_config: ClusterConfig,
+) -> AsyncGenerator[ComputerInterface, None]:
+    """Helper method for starting an AlcatrazComputerInterface given a ClusterConfig."""
+    async with cluster_config.build() as cluster:
+        yield AlcatrazComputerInterface(cluster_value=cluster)

--- a/project/paperbench/paperbench/solvers/dummy/solver.py
+++ b/project/paperbench/paperbench/solvers/dummy/solver.py
@@ -207,7 +207,7 @@ class PaperBenchDummySolver(PythonCodingSolver):
                             code_only=task.judge.code_only,
                             resources_provided=task.judge.resources_provided,
                             judge_output=None,
-                            reproduction_output=None,
+                            reproduction_metadata=None,
                         ),
                         score=0.0,
                         grader_log="",


### PR DESCRIPTION
Our reproduction execution logic was clunky and unwieldy to work with. This PR streamlines it with a bundle of quality-of-life improvements:

- Add a warning when salvaging will be skipped due to timeout configurations (otherwise it would silently skip)
- Improve logging throughout the code
- Remove stale TODOs
- Ensure explicit support for blobfile
- Consolidate `ReproductionMeta` and `ReproductionOutput` into a single structure
- Pass dataclass instances directly instead of converting to and from dictionaries
- Simplify `reproduce_on_computer` by removing:
  - Installation steps that can be handled in the Dockerfile
  - Inline try/except blocks (this logic can be moved elsewhere)
- Defer computer start until it’s actually needed
- Move `run_reproduce_on_computer` to `paperbench/scripts/run_reproduce.py` so all core reproduce logic is in one place
- Address an existing TODO and add a new TODO to integrate with the `ComputerInterface` API