### PR TITLE
[PB] ignore tests/integrations/runs/ when running mypy

### DIFF
--- a/project/paperbench/pyproject.toml
+++ b/project/paperbench/pyproject.toml
@@ -74,7 +74,7 @@ disable_error_code = ["import-untyped"]
 # allow_incomplete_defs = true
 # allow_untyped_defs = true
 # allow_any_generics = true
-exclude = "^(paperbench/agents/aisi-basic-agent)(/|$)"
+exclude = "^(paperbench/agents/aisi-basic-agent|tests/integration/runs)(/|$)"
 mypy_path = ["../alcatraz", "../preparedness_turn_completer", "../nanoeval", "../nanoeval_alcatraz"]
 [[tool.mypy.overrides]]
 module = ["alcatraz.*", "preparedness_turn_completer.*", "nanoeval.*", "nanoeval_alcatraz.*"]


### PR DESCRIPTION
Without this, mypy would pick up tests/integrations/runs/ which is a side effect dir created when we run tests, which we dont need to run mypy on.