### PR TITLE
[SWEL] minor fix necessary for monolith image

### DIFF
--- a/project/swelancer/runtime_scripts/setup_expensify.yml
+++ b/project/swelancer/runtime_scripts/setup_expensify.yml
@@ -90,17 +90,6 @@
       args:
         chdir: /app/expensify
     
-    - name: Create .env file with the environment variables
-      lineinfile:
-        path: /app/expensify/.env
-        line: '{{ item.key }}={{ item.value }}'
-        create: yes
-      with_dict:
-        PUSHER_APP_KEY: "{{ lookup('env', 'PUSHER_APP_KEY') }}"
-        USE_WEB_PROXY: "{{ lookup('env', 'USE_WEB_PROXY') }}"
-        EXPENSIFY_URL: "{{ lookup('env', 'EXPENSIFY_URL') }}"
-        NEW_EXPENSIFY_URL: "{{ lookup('env', 'NEW_EXPENSIFY_URL') }}"
-
     - name: Remove node_modules folder
       file:
         path: /app/expensify/node_modules


### PR DESCRIPTION
We noticed that evaluating IC_SWE on the monolith led to close to zero performance, despite valid rollouts. 

This was due to certain environment variables in the monolith image causing trouble with expensify flows. 

This PR removes this, fixing the zero performance issue.

We have also updated the [monolith image on docker hub](https://hub.docker.com/r/swelancer/swelancer_x86_monolith).