### PR TITLE
[swel] Remove RunnerArgs instance and update readme/tests

### DIFF
--- a/project/swelancer/README.md
+++ b/project/swelancer/README.md
@@ -122,7 +122,7 @@ uv run python swelancer/run_swelancer.py \
   runner.experimental_use_multiprocessing=False \
   runner.enable_slackbot=False \
   runner.recorder=nanoeval.recorder:dummy_recorder \
-  runner.max_retries=3
+  runner.max_retries=2
 ```
 
 Same as above but for a single issue (e.g., `28565_1001`):
@@ -144,7 +144,7 @@ uv run python swelancer/run_swelancer.py \
   runner.experimental_use_multiprocessing=False \
   runner.enable_slackbot=False \
   runner.recorder=nanoeval.recorder:dummy_recorder \
-  runner.max_retries=3
+  runner.max_retries=2
 ```
 
 We've implemented a
@@ -175,7 +175,7 @@ uv run python swelancer/run_swelancer.py \
   runner.experimental_use_multiprocessing=False \
   runner.enable_slackbot=False \
   runner.recorder=nanoeval.recorder:dummy_recorder \
-  runner.max_retries=3
+  runner.max_retries=2
 ```
 
 To run manager tasks, set `swelancer.task_type=swe_manager`. Currently, 
@@ -201,7 +201,7 @@ uv run python swelancer/run_swelancer.py \
   runner.experimental_use_multiprocessing=False \
   runner.enable_slackbot=False \
   runner.recorder=nanoeval.recorder:dummy_recorder \
-  runner.max_retries=3
+  runner.max_retries=2
 ```
 
 ### Logging

--- a/project/swelancer/swelancer/run_swelancer.py
+++ b/project/swelancer/swelancer/run_swelancer.py
@@ -6,7 +6,6 @@ import chz
 import nanoeval
 from nanoeval.eval import EvalSpec, RunnerArgs
 from nanoeval.library_config import LibraryConfig
-from nanoeval.recorder import dummy_recorder
 from nanoeval.setup import nanoeval_entrypoint
 from swelancer.eval import SWELancerEval
 from swelancer.utils.custom_logging import (
@@ -16,18 +15,10 @@ from swelancer.utils.custom_logging import (
     swelancer_library_config as default_library_config,
 )
 
-default_runner = RunnerArgs(
-    concurrency=20,
-    experimental_use_multiprocessing=False,
-    enable_slackbot=False,
-    recorder=dummy_recorder(),
-    max_retries=0,
-)
-
 
 async def main(
     swelancer: SWELancerEval,
-    runner: RunnerArgs = default_runner,
+    runner: RunnerArgs,
     library_config: LibraryConfig = default_library_config,
 ) -> None:
     setup_logging(library_config)

--- a/project/swelancer/tests/integration/test_dummy.py
+++ b/project/swelancer/tests/integration/test_dummy.py
@@ -59,7 +59,7 @@ async def test_gold_patch_passes_tests_using_local_cluster(issue_id: str) -> Non
         experimental_use_multiprocessing=False,
         enable_slackbot=False,
         recorder=dummy_recorder(),
-        max_retries=0,
+        max_retries=2,
     )
 
     solver = DummySolver(


### PR DESCRIPTION
The RunnerArgs instance with recommended was not actually being picked up by chz.

So in this PR we just remove the instantiation to reduce confusion and make sure we have the right args in README.