### PR TITLE
[PB] dont pass around boundloggers; instantiate when needed

### DIFF
--- a/project/paperbench/paperbench/grade.py
+++ b/project/paperbench/paperbench/grade.py
@@ -12,7 +12,6 @@ from typing import Any
 import blobfile as bf
 import structlog.stdlib
 from preparedness_turn_completer.turn_completer import TurnCompleter
-from structlog.stdlib import BoundLogger
 
 from nanoeval.solvers.computer_tasks.code_execution_interface import ComputerInterface
 from paperbench.judge.create_judge import create_judge, handle_judge_kwargs
@@ -138,7 +137,9 @@ async def grade_submission(
     paper_id: str,
     judge_type: str,
     completer_config: TurnCompleter.Config,
-    logger: BoundLogger,
+    run_group_id: str,
+    runs_dir: str,
+    run_id: str,
     code_only: bool = False,
     resources_provided: bool = False,
     computer: ComputerInterface | None = None,
@@ -151,8 +152,12 @@ async def grade_submission(
     - Upload the judge results
     """
 
+    ctx_logger = logger.bind(
+        run_group_id=run_group_id, runs_dir=runs_dir, run_id=run_id, destinations=["run"]
+    )
+
     time_start = time.time()
-    logger.info(f"Grading {submission_path} for paper {paper_id}")
+    ctx_logger.info(f"Grading {submission_path} for paper {paper_id}")
 
     judge_output = None
     error_msg = None
@@ -166,12 +171,14 @@ async def grade_submission(
 
             # Step 1: Unzip submission from submission_path to tmp dir
             if computer:
-                await put_submission_in_computer(computer, submission_path, logger)
+                await put_submission_in_computer(
+                    computer, submission_path, run_group_id, runs_dir, run_id
+                )
             else:
                 with bf.BlobFile(submission_path, "rb") as f:
                     with tarfile.open(fileobj=f, mode="r") as tar:
                         tar.extractall(path=submission_dir)
-            logger.info(f"Unzipped submission for judge to {submission_dir}")
+            ctx_logger.info(f"Unzipped submission for judge to {submission_dir}")
 
             # Step 2: Run the judge
             graded_task_tree = await run_judge(
@@ -186,7 +193,7 @@ async def grade_submission(
             if judge_type == "simple":
                 token_usage = get_total_token_usage(graded_task_tree)
 
-            logger.info(f"Graded {paper_id} at {submission_path}")
+            ctx_logger.info(f"Graded {paper_id} at {submission_path}")
 
             judge_output = JudgeOutput(
                 judge_type=judge_type,
@@ -208,12 +215,12 @@ async def grade_submission(
                 grader_upload_path,
                 json.dumps(judge_output.to_dict(), indent=4).encode("utf-8"),
             )
-            logger.info(f"Grading results have been written to file: {grader_upload_path}")
+            ctx_logger.info(f"Grading results have been written to file: {grader_upload_path}")
     except Exception as e:
         error_msg = str(e)
-        logger.exception(f"Grading failed with error:\n{error_msg}")
+        ctx_logger.exception(f"Grading failed with error:\n{error_msg}")
     finally:
         time_end = time.time()
-        logger.info(f"Grading completed in {time_end - time_start:.2f} seconds.")
+        ctx_logger.info(f"Grading completed in {time_end - time_start:.2f} seconds.")
 
     return judge_output

--- a/project/paperbench/paperbench/nano/eval.py
+++ b/project/paperbench/paperbench/nano/eval.py
@@ -317,7 +317,6 @@ class ExternalPythonCodingSolver(PythonCodingSolver):
                 paper=paper,
                 agent=agent,
                 run_dir=task.run_dir,
-                logger=ctx_logger.bind(destinations=["run"]),
                 agent_dir_config=self.agent_dir_config,
                 timeout=self.timeout,
                 upload_interval_messages=self.upload_interval_messages,

--- a/project/paperbench/paperbench/nano/task.py
+++ b/project/paperbench/paperbench/nano/task.py
@@ -107,7 +107,10 @@ class PBTask(ComputerTask):
         Specifically, sets up the files and folders necessary for attempting the PBTask.
         """
         ctx_logger = logger.bind(
-            run_group_id=self.run_group_id, run_id=self.run_id, runs_dir=self.runs_dir
+            run_group_id=self.run_group_id,
+            runs_dir=self.runs_dir,
+            run_id=self.run_id,
+            destinations=["run"],
         )
 
         paper = paper_registry.get_paper(self.paper_id)
@@ -168,7 +171,9 @@ class PBTask(ComputerTask):
                     agent_start_time=int(time.time()),
                     agent_dir_config=prepare_agent_dir_config(),
                     run_dir=self.run_dir,
-                    logger=ctx_logger.bind(destinations=["run"]),
+                    run_group_id=self.run_group_id,
+                    runs_dir=self.runs_dir,
+                    run_id=self.run_id,
                 )
                 await upload_status(
                     start_time=int(time.time()),
@@ -383,7 +388,9 @@ class PBTask(ComputerTask):
             metadata = await reproduce_on_computer_with_salvaging(
                 cluster_config=self.reproduction.cluster_config,
                 submission_path=submission,
-                logger=ctx_logger.bind(destinations=["run"]),
+                run_group_id=self.run_group_id,
+                runs_dir=self.runs_dir,
+                run_id=self.run_id,
                 run_dir=self.run_dir,
                 timeout=self.reproduction.timeout,
                 retry_threshold=self.reproduction.retry_threshold,
@@ -494,7 +501,9 @@ class PBTask(ComputerTask):
                 paper_id=paper_id,
                 judge_type=self.judge.scaffold,
                 completer_config=self.judge.completer_config,
-                logger=ctx_logger.bind(destinations=["run"]),
+                run_group_id=self.run_group_id,
+                runs_dir=self.runs_dir,
+                run_id=self.run_id,
                 code_only=self.judge.code_only,
                 computer=computer,
                 resources_provided=self.judge.resources_provided,


### PR DESCRIPTION
We were still passing around `BoundLogger`s here and there. 

In this PR we change this so we pass the variables necessary for the context and bind the context when necesary, relying on the file's logger instead of passing