### PR TITLE
[PB] cleanup small TODOs

### DIFF
--- a/project/paperbench/paperbench/agents/utils.py
+++ b/project/paperbench/paperbench/agents/utils.py
@@ -83,7 +83,10 @@ async def check_for_existing_run(task: PBTask) -> AgentOutput | None:
 
 
 def log_messages_to_file(
-    messages: list[ChatCompletionMessageParam], file_path: str, width: int = 100
+    messages: list[ChatCompletionMessageParam],
+    file_path: str,
+    width: int = 100,
+    max_lines_per_message: int = 600,
 ) -> None:
     """
     Write a human-readable log of messages to file_path.
@@ -118,7 +121,14 @@ def log_messages_to_file(
             )
             lines.extend(wrapped)
 
-        # TODO truncate content if it's too long
+        if len(lines) > max_lines_per_message:
+            head = max_lines_per_message // 2
+            tail = max_lines_per_message - head - 1
+            omitted = len(lines) - (head + tail)
+            sentinel = (
+                f"...[logs truncated for readability and portability: {omitted} lines omitted]..."
+            )
+            lines = lines[:head] + [sentinel] + (lines[-tail:] if tail > 0 else [])
 
         return [line.ljust(inner_width) for line in lines]
 

--- a/project/paperbench/paperbench/infra/alcatraz.py
+++ b/project/paperbench/paperbench/infra/alcatraz.py
@@ -148,7 +148,7 @@ async def upload_sources(
     cmds = [
         f"ARCHIVE_PATH={container_tar_path}",
         "EXCLUDE_LIST=/tmp/exclude.txt",
-        f"tar -czf $ARCHIVE_PATH -X $EXCLUDE_LIST -C {container_tmp_dir.parent} '{timestamp}'",
+        f"tar -czf $ARCHIVE_PATH -X $EXCLUDE_LIST -C {container_tmp_dir} .",
     ]
 
     await computer.check_shell_command(" && ".join(cmds))

--- a/project/paperbench/paperbench/judge/judge_eval/registry.py
+++ b/project/paperbench/paperbench/judge/judge_eval/registry.py
@@ -64,7 +64,6 @@ class ExampleRunRegistry:
 
     def get_default_dataset_dir(self) -> Path:
         """Returns the default dataset directory."""
-        # TODO change this to a more appropriate default (e.g. ~/.cache/hp/judge_eval/) at release (when we will not be e.g. committing/directly redistributing the code)
         return get_paperbench_data_dir() / "judge_eval"
 
     def get_examples_dir(self) -> Path:

--- a/project/paperbench/paperbench/nano/task.py
+++ b/project/paperbench/paperbench/nano/task.py
@@ -188,7 +188,7 @@ class PBTask(ComputerTask):
                     f"Exception uploading final logs before grading: {e}", destinations=["run"]
                 )
 
-    def _early_exit_grade(
+    def early_exit_grade(
         self,
         grader_log: str,
         monitor_ran: bool = False,
@@ -263,7 +263,7 @@ class PBTask(ComputerTask):
         checkpoint = await self._select_checkpoint()
         if not checkpoint:
             ctx_logger.exception("No checkpoint exists, skipping grading!", destinations=["run"])
-            return self._early_exit_grade("No checkpoint exists, skipping grading!")
+            return self.early_exit_grade("No checkpoint exists, skipping grading!")
         path_to_submission, _ = checkpoint
         path_to_executed_submission = path_to_submission.replace(".tar.gz", "_executed.tar.gz")
 
@@ -280,7 +280,7 @@ class PBTask(ComputerTask):
                     f"Submission for {self.run_id} flagged by monitor",
                     destinations=["group", "run"],
                 )
-                return self._early_exit_grade(
+                return self.early_exit_grade(
                     "Submission flagged by monitor", monitor_ran=mon_ran, monitor_result=mon_result
                 )
 

--- a/project/paperbench/paperbench/paper_registry.py
+++ b/project/paperbench/paperbench/paper_registry.py
@@ -51,7 +51,7 @@ class Paper:
                 blacklist=data["blacklist"],
             )
         except KeyError as e:
-            raise ValueError("Missing key in paper config!") from e
+            raise ValueError(f"Missing key in paper config! {e}") from e
 
 
 class PaperRegistry:

--- a/project/paperbench/paperbench/rubric/tasks.py
+++ b/project/paperbench/paperbench/rubric/tasks.py
@@ -15,7 +15,7 @@ VALID_TASK_CATEGORIES = {
     "Code Development",
     "Code Execution",
     "Result Analysis",
-    "Subtree",
+    "Subtree",  # Used dynamically for experimental non-leaf grading
 }
 
 VALID_FINEGRAINED_TASK_CATEGORIES = {
@@ -61,19 +61,19 @@ class TaskNode:
             raise ValueError("Weight must be non-negative.")
 
         if self.task_category and self.task_category not in VALID_TASK_CATEGORIES:
-            logger.warning(f"Invalid task category: {self.task_category}")
+            raise ValueError(f"Invalid task category: {self.task_category}")
 
         if (
             self.finegrained_task_category
             and self.finegrained_task_category not in VALID_FINEGRAINED_TASK_CATEGORIES
         ):
-            logger.warning(f"Invalid finegrained task category: {self.finegrained_task_category}")
+            raise ValueError(f"Invalid finegrained task category: {self.finegrained_task_category}")
 
         if not self.is_leaf() and self.task_category:
             raise ValueError(f"Non-leaf node '{self.id}' cannot have a task category.")
 
         if self.is_leaf() and not self.task_category:
-            logger.warning(f"Leaf node '{self.id}' doesn't have a task category.")
+            raise ValueError(f"Leaf node '{self.id}' doesn't have a task category.")
 
     def is_leaf(self) -> bool:
         """Check if the node is a leaf node (has no sub-tasks)."""

--- a/project/paperbench/tests/integration/test_run_agent.py
+++ b/project/paperbench/tests/integration/test_run_agent.py
@@ -199,14 +199,8 @@ def _get_rollout(runs_dir: str) -> Rollout:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with tarfile.open(local_submission, "r:gz") as tf:
-                for member in tf.getmembers():
-                    assert member.name.startswith(latest), (
-                        f"Expected one extracted folder called {latest} in submission.tar.gz file, "
-                        f"but found {member.name}!"
-                    )
-
-                    member.name = member.name[len(latest) + 1 :]
-                    tf.extract(member, path=tmpdir)
+                # archives extract directly with top-level 'submission/' (and optionally 'logs/')
+                tf.extractall(path=tmpdir)
 
             for root, _, files in os.walk(tmpdir):
                 for fname in files:

--- a/project/paperbench/tests/unit/test_rubrics_load.py
+++ b/project/paperbench/tests/unit/test_rubrics_load.py
@@ -1,0 +1,28 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from paperbench.paper_registry import paper_registry
+from paperbench.rubric.tasks import TaskNode
+
+# Discover all paper IDs from the registry once for parametrization
+PAPER_IDS = paper_registry.list_paper_ids()
+
+
+@pytest.mark.parametrize("paper_id", PAPER_IDS)
+def test_rubric_loads_into_tasknode_without_error(paper_id: str) -> None:
+    # Given
+    paper = paper_registry.get_paper(paper_id)
+    rubric_path: Path = paper.rubric
+    assert rubric_path.exists(), f"Rubric file does not exist for paper '{paper_id}': {rubric_path}"
+
+    # When
+    with open(rubric_path, "r") as f:
+        data = json.load(f)
+    task_tree = TaskNode.from_dict(data)
+
+    # Then
+    assert isinstance(task_tree, TaskNode), (
+        f"Expected a TaskNode when loading rubric for paper '{paper_id}', got {type(task_tree)}"
+    )


### PR DESCRIPTION
- removing stale TODOs
- Now that rubrics are finalized, invalid rubrics will error rather than warn
- Truncate overly long content in basicagent's agent.log
- (somewhat larger): Remove "hack" we were doing for put_submission_in_computer. To do this we unify the way submissions are tarred between the agents and reproducer, by removing an unnecessary timestamp in the agent archive.
- Address TODO in the Paperbench base solver where we were mistakingly raising RolloutSystemError's for non-system errors:

There's a few more TODOs that we will address with separate PRs