### PR TITLE
Pin pre-commit hook revisions to immutable commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_stages: [pre-commit, pre-push]
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.2
+    rev: 73413df07b4ab0bf103ca1ae73c7cec5c0ace593  # pinned from v0.9.2
     hooks:
       # black-compatible formatter, Runs first so later lint hooks see the formatted code
       # picks up config from [tool.ruff] in pyproject.toml
@@ -29,7 +29,7 @@ repos:
 
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.6.14
+    rev: 3ed2640a6d0df495ffe343ee0beb77a80c73a3ae  # pinned from 0.6.14
     hooks:
       - id: uv-lock
         name: uv-lock-paperbench


### PR DESCRIPTION
## What's changing
Replace non-commit `rev:` values in pre-commit config files with the exact commit those refs resolve to today.

## Why
Tags and branch names can be retargeted upstream; pinning to immutable commits hardens our software supply chain posture and keeps the selected code the same over time.
