### PR TITLE
Fix BasicAgent real-time progress reminder

### DIFF
--- a/project/paperbench/paperbench/solvers/basicagent/solver.py
+++ b/project/paperbench/paperbench/solvers/basicagent/solver.py
@@ -210,7 +210,7 @@ class BasicAgentSolver(BasePBSolver):
         if self.use_real_time_limit and self.time_limit:
             elapsed_time = time.time() - start_time - total_retry_time
             periodic_msg = f"Info: {format_progress_time(elapsed_time)} time elapsed out of {format_progress_time(self.time_limit)}. Remember, you only have to stop working when the time limit has been reached."
-        if self.time_limit:
+        elif self.time_limit:
             elapsed_time = time.time() - start_time
             periodic_msg = f"Info: {format_progress_time(elapsed_time)} time elapsed out of {format_progress_time(self.time_limit)}. Remember, you only have to stop working when the time limit has been reached."
         else:

--- a/project/paperbench/tests/unit/test_basicagent_solver.py
+++ b/project/paperbench/tests/unit/test_basicagent_solver.py
@@ -1,0 +1,26 @@
+from paperbench.solvers.basicagent import solver
+from paperbench.solvers.basicagent.solver import BasicAgentSolver
+
+
+def test_periodic_reminder_uses_retry_adjusted_elapsed_time(monkeypatch):
+    monkeypatch.setattr(solver.time, "time", lambda: 1_100.0)
+    agent = BasicAgentSolver(time_limit=200, use_real_time_limit=True)
+
+    message = agent._construct_periodic_reminder(
+        start_time=1_000.0,
+        total_retry_time=40.0,
+    )
+
+    assert "0:01:00 time elapsed out of  0:03:20" in message["content"]
+
+
+def test_periodic_reminder_uses_wall_clock_when_real_time_disabled(monkeypatch):
+    monkeypatch.setattr(solver.time, "time", lambda: 1_100.0)
+    agent = BasicAgentSolver(time_limit=200, use_real_time_limit=False)
+
+    message = agent._construct_periodic_reminder(
+        start_time=1_000.0,
+        total_retry_time=40.0,
+    )
+
+    assert "0:01:40 time elapsed out of  0:03:20" in message["content"]


### PR DESCRIPTION
## Summary
- fix `_construct_periodic_reminder` so the retry-adjusted elapsed time branch is not overwritten when `use_real_time_limit=True`
- add regression tests for retry-adjusted and wall-clock reminder behavior

Fixes #112
/claim #112

## Bounty
- Algora: https://algora.io/PrimeIntellect-ai/bounties/RyPmLNGKSWA9D5yJ

## Validation
- `uv run --project project/paperbench pytest project/paperbench/tests/unit/test_basicagent_solver.py -q`
- `uv run --project project/paperbench ruff check project/paperbench/paperbench/solvers/basicagent/solver.py project/paperbench/tests/unit/test_basicagent_solver.py`
- `git diff --check`