### PR TITLE
Add security disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please do not open a public GitHub issue or pull request for a suspected security vulnerability.
+
+Report security issues through OpenAI's vulnerability disclosure program:
+
+https://openai.com/security/disclosure/
+
+Include enough detail for maintainers to reproduce and assess the issue, such as affected code paths, environment details, impact, and proof-of-concept steps if available. OpenAI will coordinate follow-up through the disclosure program.


### PR DESCRIPTION
Closes #113.

## Summary
- Add a root `SECURITY.md` that directs suspected vulnerabilities to OpenAI's vulnerability disclosure program.
- Clarify that security reports should not be opened as public issues or PRs.

## Validation
- `git diff --check`

This is a housekeeping/security-process PR and is not a bounty claim.