### PR TITLE
Fix SWELancer user tool trace export

### DIFF
--- a/project/swelancer/issues/16912_4/user_tool.py
+++ b/project/swelancer/issues/16912_4/user_tool.py
@@ -73,7 +73,6 @@ def test_unknown_user_profile_load_offline():
         raise e
     finally:
         # Ensure the trace is stopped and exported, even if the test fails
-        context.tracing.stop()
-        context.tracing.export(trace_path)
+        context.tracing.stop(path=trace_path)
         # Call the trace cleaner on the saved trace
         trace_cleaner(trace_path)

--- a/project/swelancer/issues/17387_1/user_tool.py
+++ b/project/swelancer/issues/17387_1/user_tool.py
@@ -78,9 +78,8 @@ def test_expensify_17387():
             print(f"An error occurred: {e}")
         finally:
             # Stop tracing and export
-            context.tracing.stop()
             trace_path = "/app/expensify/user_tool/output_browser1.zip"
-            context.tracing.export(path=trace_path)
+            context.tracing.stop(path=trace_path)
             # Clean the trace
             trace_cleaner(trace_path)
 

--- a/project/swelancer/issues/29854_602/user_tool.py
+++ b/project/swelancer/issues/29854_602/user_tool.py
@@ -130,7 +130,8 @@ async def test_the_issue(page):
         raise e
     finally:
         # Stop tracing and export
-        await page.context.tracing.stop()
-        await page.context.tracing.export(path="/app/expensify/user_tool/output_browser1.zip")
+        await page.context.tracing.stop(
+            path="/app/expensify/user_tool/output_browser1.zip"
+        )
         # Clean the trace
         trace_cleaner("/app/expensify/user_tool/output_browser1.zip")


### PR DESCRIPTION
## Summary
- replace obsolete Playwright `tracing.export(...)` calls in SWELancer `user_tool.py` files with `tracing.stop(path=...)`
- update both sync and async user-tool variants reported in #99
- leave the existing trace-cleaner calls and output paths unchanged

Fixes #99

## Validation
- `uv run python -m py_compile project/swelancer/issues/16912_4/user_tool.py project/swelancer/issues/17387_1/user_tool.py project/swelancer/issues/29854_602/user_tool.py`
- `rg -n "tracing\.export" project/swelancer/issues/*/user_tool.py` returns no matches
- `git diff --check`

Note: I did not run the full Playwright/Expensify browser flow locally; this is a deterministic API misuse fix and matches the existing `context.tracing.stop(path=trace_path)` pattern already used across SWELancer `test.py` files.