### PR TITLE
fix(paperbench): respect use_real_time_limit in BasicAgent periodic reminder

### DIFF
--- a/project/paperbench/paperbench/solvers/basicagent/solver.py
+++ b/project/paperbench/paperbench/solvers/basicagent/solver.py
@@ -210,7 +210,7 @@ class BasicAgentSolver(BasePBSolver):
         if self.use_real_time_limit and self.time_limit:
             elapsed_time = time.time() - start_time - total_retry_time
             periodic_msg = f"Info: {format_progress_time(elapsed_time)} time elapsed out of {format_progress_time(self.time_limit)}. Remember, you only have to stop working when the time limit has been reached."
-        if self.time_limit:
+        elif self.time_limit:
             elapsed_time = time.time() - start_time
             periodic_msg = f"Info: {format_progress_time(elapsed_time)} time elapsed out of {format_progress_time(self.time_limit)}. Remember, you only have to stop working when the time limit has been reached."
         else:

--- a/project/paperbench/tests/unit/test_basicagent_periodic_reminder.py
+++ b/project/paperbench/tests/unit/test_basicagent_periodic_reminder.py
@@ -1,0 +1,60 @@
+"""Unit tests for BasicAgentSolver._construct_periodic_reminder.
+
+Regression coverage for the missing-`elif` bug described in
+https://github.com/openai/frontier-evals/issues/112: with the original
+control flow, the wall-clock branch always ran after the
+retry-adjusted branch and silently overwrote `elapsed_time`, so
+`use_real_time_limit=True` was a no-op for the periodic reminder.
+"""
+
+from paperbench.solvers.basicagent import solver
+from paperbench.solvers.basicagent.solver import BasicAgentSolver
+
+
+def test_periodic_reminder_subtracts_retry_time_when_real_time_limit_enabled(
+    monkeypatch,
+) -> None:
+    """With `use_real_time_limit=True`, retry waits must be excluded."""
+    monkeypatch.setattr(solver.time, "time", lambda: 1_100.0)
+    agent = BasicAgentSolver(time_limit=200, use_real_time_limit=True)
+
+    message = agent._construct_periodic_reminder(
+        start_time=1_000.0,
+        total_retry_time=40.0,
+    )
+
+    # elapsed = (1100 - 1000) - 40 = 60s -> " 0:01:00"
+    assert " 0:01:00 time elapsed out of  0:03:20" in message["content"]
+
+
+def test_periodic_reminder_uses_wall_clock_when_real_time_limit_disabled(
+    monkeypatch,
+) -> None:
+    """With `use_real_time_limit=False`, the reminder reports raw wall-clock."""
+    monkeypatch.setattr(solver.time, "time", lambda: 1_100.0)
+    agent = BasicAgentSolver(time_limit=200, use_real_time_limit=False)
+
+    message = agent._construct_periodic_reminder(
+        start_time=1_000.0,
+        total_retry_time=40.0,
+    )
+
+    # elapsed = 1100 - 1000 = 100s -> " 0:01:40"
+    assert " 0:01:40 time elapsed out of  0:03:20" in message["content"]
+
+
+def test_periodic_reminder_falls_back_to_unlimited_message_when_no_time_limit(
+    monkeypatch,
+) -> None:
+    """With `time_limit=None`, the reminder omits the deadline phrasing."""
+    monkeypatch.setattr(solver.time, "time", lambda: 1_100.0)
+    agent = BasicAgentSolver(time_limit=None, use_real_time_limit=True)
+
+    message = agent._construct_periodic_reminder(
+        start_time=1_000.0,
+        total_retry_time=40.0,
+    )
+
+    content = message["content"]
+    assert " 0:01:40 time elapsed" in content
+    assert "out of" not in content


### PR DESCRIPTION
## Summary

`_construct_periodic_reminder` in `paperbench/solvers/basicagent/solver.py` is missing an `elif` between two `if` blocks. With the current control flow, when `use_real_time_limit=True` and `time_limit` is set, **both** of the first two branches execute and the second one always overwrites `elapsed_time`, so the periodic reminder always reports raw wall-clock time regardless of `use_real_time_limit`.

`_has_agent_finished` in the same module already uses the intended `if / elif / else` structure for the same three cases — the periodic reminder just forgot the `elif`.

Fixes #112.

## The bug

```python
# Before
if self.use_real_time_limit and self.time_limit:
    elapsed_time = time.time() - start_time - total_retry_time   # set...
    periodic_msg = ...
if self.time_limit:                                              # ...then unconditionally overwritten
    elapsed_time = time.time() - start_time
    periodic_msg = ...
else:
    elapsed_time = time.time() - start_time
    periodic_msg = ...
```

Net effect: the agent receives misleading time-pressure signals on slow / rate-limited endpoints, where retry waits accumulate and the reminder reports a deadline much closer than `_has_agent_finished` is actually enforcing.

## Fix

Change the second `if` to `elif` so the three branches are mutually exclusive, matching `_has_agent_finished`.

## Tests

Added `project/paperbench/tests/unit/test_basicagent_periodic_reminder.py` with one test per branch:

- `use_real_time_limit=True` + `time_limit` set → retry-adjusted elapsed time.
- `use_real_time_limit=False` + `time_limit` set → wall-clock elapsed with deadline phrasing.
- `time_limit=None` → wall-clock fallback message without the "out of …" clause.

Verification:

```
$ uv run pytest tests/unit/test_basicagent_periodic_reminder.py -v
3 passed, 23 warnings in 40.32s

$ uv run ruff check paperbench/solvers/basicagent/solver.py tests/unit/test_basicagent_periodic_reminder.py
All checks passed!

$ uv run ruff format --check paperbench/solvers/basicagent/solver.py tests/unit/test_basicagent_periodic_reminder.py
2 files already formatted
```

## Notes

A previous attempt at this fix was opened in #114 and self-closed by the author with a note about scope/queue management; the underlying issue #112 is still open and the fix is unchanged from the one the reporter suggested (the only mechanically correct rewrite is `if` → `elif`). This PR re-submits the change with independent test coverage for all three branches.