### PR TITLE
Harden PaperBench tar extraction

### DIFF
--- a/project/paperbench/paperbench/computer_utils.py
+++ b/project/paperbench/paperbench/computer_utils.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import shlex
+import textwrap
 import uuid
 from contextlib import AsyncExitStack, asynccontextmanager, suppress
 from typing import Any, AsyncGenerator
@@ -22,6 +24,52 @@ from paperbench.utils import find_dotenv
 load_dotenv(find_dotenv())
 
 logger = structlog.stdlib.get_logger(component=__name__)
+
+
+def _safe_remote_tar_extract_command(tar_path: str, extract_dir: str) -> str:
+    """Build a remote command that extracts a tarball without path traversal."""
+
+    script = textwrap.dedent(
+        r"""
+import inspect
+import os
+import tarfile
+from pathlib import Path
+
+
+def is_within_directory(directory: Path, target: Path) -> bool:
+    return os.path.commonpath([str(directory), str(target)]) == str(directory)
+
+
+def validate_member(member: tarfile.TarInfo, destination: Path) -> None:
+    target = (destination / member.name).resolve()
+    if not is_within_directory(destination, target):
+        raise tarfile.TarError(f"Tar member would extract outside destination: {member.name}")
+
+    if member.isdev():
+        raise tarfile.TarError(f"Refusing to extract special file from tar archive: {member.name}")
+
+    if member.issym() or member.islnk():
+        raise tarfile.TarError(f"Refusing to extract link from tar archive: {member.name}")
+
+
+destination = Path(os.environ["EXTRACT_DIR"]).resolve()
+with tarfile.open(os.environ["TAR_PATH"], "r:gz") as archive:
+    if "filter" in inspect.signature(archive.extractall).parameters:
+        archive.extractall(path=destination, filter="data")
+    else:
+        members = archive.getmembers()
+        for member in members:
+            validate_member(member, destination)
+        archive.extractall(path=destination, members=members)
+"""
+    ).strip()
+    return (
+        f"mkdir -p {shlex.quote(extract_dir)} && \\\n"
+        f"TAR_PATH={shlex.quote(tar_path)} EXTRACT_DIR={shlex.quote(extract_dir)} python3 - <<'PY'\n"
+        f"{script}\n"
+        "PY"
+    )
 
 
 async def put_submission_in_computer(
@@ -48,7 +96,7 @@ async def put_submission_in_computer(
 
     # Extract tar.gz into a unique temp dir to avoid collisions.
     extract_dir = f"/tmp/pb_extract_{uuid.uuid4().hex}"
-    cmd = f"mkdir -p {extract_dir} && tar -xzf {tar_gz_on_computer} -C {extract_dir}"
+    cmd = _safe_remote_tar_extract_command(tar_gz_on_computer, extract_dir)
     ctx_logger.info(f"Extracting submission: {cmd}")
     result = await computer.check_shell_command(cmd)
 

--- a/project/paperbench/paperbench/grade.py
+++ b/project/paperbench/paperbench/grade.py
@@ -20,6 +20,7 @@ from paperbench.judge.graded_task_node import GradedTaskNode
 from paperbench.judge.token_usage import TokenUsage, get_total_token_usage
 from paperbench.paper_registry import paper_registry
 from paperbench.rubric.tasks import TaskNode
+from paperbench.tar_utils import safe_extractall
 from paperbench.utils import get_timestamp
 
 logger = structlog.stdlib.get_logger(component=__name__)
@@ -177,7 +178,7 @@ async def grade_submission(
             else:
                 with bf.BlobFile(submission_path, "rb") as f:
                     with tarfile.open(fileobj=f, mode="r") as tar:
-                        tar.extractall(path=submission_dir)
+                        safe_extractall(tar, submission_dir)
             ctx_logger.info(f"Unzipped submission for judge to {submission_dir}")
 
             # Step 2: Run the judge

--- a/project/paperbench/paperbench/scripts/run_monitor.py
+++ b/project/paperbench/paperbench/scripts/run_monitor.py
@@ -15,6 +15,7 @@ from tqdm.asyncio import tqdm_asyncio
 import chz
 from paperbench.monitor.monitor import BasicMonitor, Monitor
 from paperbench.paper_registry import paper_registry
+from paperbench.tar_utils import safe_extractall
 
 logger = structlog.stdlib.get_logger(component=__name__)
 
@@ -81,7 +82,7 @@ async def monitor_single_log(
 
     with tempfile.TemporaryDirectory() as extract_to:
         with tarfile.open(latest_checkpoint / "submission.tar.gz", "r:gz") as tar:
-            tar.extractall(path=extract_to)
+            safe_extractall(tar, extract_to)
 
         matches = list(Path(extract_to).glob("**/logs/agent.log"))
         assert len(matches) == 1, f"Expected exactly one agent.log file, found {len(matches)}"

--- a/project/paperbench/paperbench/tar_utils.py
+++ b/project/paperbench/paperbench/tar_utils.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import inspect
+import os
+import tarfile
+from pathlib import Path
+
+
+def _is_within_directory(directory: Path, target: Path) -> bool:
+    return os.path.commonpath([directory, target]) == str(directory)
+
+
+def _validate_member(member: tarfile.TarInfo, destination: Path) -> None:
+    target = (destination / member.name).resolve()
+    if not _is_within_directory(destination, target):
+        raise tarfile.TarError(f"Tar member would extract outside destination: {member.name}")
+
+    if member.isdev():
+        raise tarfile.TarError(f"Refusing to extract special file from tar archive: {member.name}")
+
+    if member.issym() or member.islnk():
+        raise tarfile.TarError(f"Refusing to extract link from tar archive: {member.name}")
+
+
+def safe_extractall(tar: tarfile.TarFile, path: str | Path) -> None:
+    """Extract a tar archive without allowing path traversal or special files."""
+
+    destination = Path(path).resolve()
+
+    if "filter" in inspect.signature(tar.extractall).parameters:
+        tar.extractall(path=destination, filter="data")
+        return
+
+    members = tar.getmembers()
+    for member in members:
+        _validate_member(member, destination)
+
+    tar.extractall(path=destination, members=members)

--- a/project/paperbench/tests/unit/computer_utils/test_put_submission_in_computer.py
+++ b/project/paperbench/tests/unit/computer_utils/test_put_submission_in_computer.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import pytest
+
+from nanoeval.solvers.computer_tasks.code_execution_interface import (
+    ComputerInterface,
+    ExecutionResult,
+    JupyterExecutionResult,
+)
+from paperbench import computer_utils
+
+
+class RecordingComputer(ComputerInterface):
+    def __init__(self) -> None:
+        self.commands: list[str] = []
+
+    async def disable_internet(self) -> None:  # pragma: no cover - not used
+        raise NotImplementedError
+
+    async def upload(self, file: bytes, destination: str) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+    async def download(self, file: str) -> bytes:  # pragma: no cover
+        raise NotImplementedError
+
+    async def send_shell_command(self, cmd: str, *, idempotent: bool = False) -> ExecutionResult:
+        self.commands.append(cmd)
+        return ExecutionResult(output=b"ok", exit_code=0)
+
+    async def fetch_container_names(self) -> list[str]:  # pragma: no cover
+        raise NotImplementedError
+
+    async def stop(self) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+    async def execute(self, code: str, timeout: int = 120) -> JupyterExecutionResult:
+        raise NotImplementedError
+
+
+@pytest.mark.asyncio
+async def test_put_submission_in_computer_uses_safe_tar_extraction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    copied_files: list[tuple[str, str]] = []
+
+    async def fake_put_file_in_computer(
+        *,
+        computer: ComputerInterface,
+        blobfile_path: str,
+        dest_path: str,
+        run_group_id: str,
+        runs_dir: str,
+        run_id: str,
+    ) -> None:
+        copied_files.append((blobfile_path, dest_path))
+
+    monkeypatch.setattr(computer_utils, "put_file_in_computer", fake_put_file_in_computer)
+
+    computer = RecordingComputer()
+    await computer_utils.put_submission_in_computer(
+        computer=computer,
+        submission_path="/tmp/submission.tar.gz",
+        run_group_id="group",
+        runs_dir="/tmp/runs",
+        run_id="run",
+    )
+
+    assert copied_files == [("/tmp/submission.tar.gz", "/tmp/logs.tar.gz")]
+
+    extract_command = computer.commands[0]
+    assert "tar -xzf" not in extract_command
+    assert "tarfile.open" in extract_command
+    assert 'filter="data"' in extract_command
+    assert "validate_member" in extract_command
+
+    assert computer.commands[1].startswith("rm -rf /submission && mv /tmp/pb_extract_")
+    assert computer.commands[1].endswith("/submission /submission")
+    assert computer.commands[2] == "ls -la /submission"

--- a/project/paperbench/tests/unit/test_tar_utils.py
+++ b/project/paperbench/tests/unit/test_tar_utils.py
@@ -1,0 +1,64 @@
+import io
+import tarfile
+
+import pytest
+
+from paperbench.tar_utils import safe_extractall
+
+
+def _tar_with_file(name: str, contents: bytes = b"contents") -> io.BytesIO:
+    fileobj = io.BytesIO()
+    with tarfile.open(fileobj=fileobj, mode="w") as tar:
+        info = tarfile.TarInfo(name)
+        info.size = len(contents)
+        tar.addfile(info, io.BytesIO(contents))
+    fileobj.seek(0)
+    return fileobj
+
+
+def _tar_with_symlink(name: str, linkname: str) -> io.BytesIO:
+    fileobj = io.BytesIO()
+    with tarfile.open(fileobj=fileobj, mode="w") as tar:
+        info = tarfile.TarInfo(name)
+        info.type = tarfile.SYMTYPE
+        info.linkname = linkname
+        tar.addfile(info)
+    fileobj.seek(0)
+    return fileobj
+
+
+def test_safe_extractall_extracts_regular_files(tmp_path):
+    with tarfile.open(fileobj=_tar_with_file("submission/result.txt"), mode="r") as tar:
+        safe_extractall(tar, tmp_path)
+
+    assert (tmp_path / "submission" / "result.txt").read_bytes() == b"contents"
+
+
+def test_safe_extractall_rejects_path_traversal(tmp_path):
+    outside_file = tmp_path.parent / "escaped.txt"
+
+    with tarfile.open(fileobj=_tar_with_file("../escaped.txt"), mode="r") as tar:
+        with pytest.raises(tarfile.TarError):
+            safe_extractall(tar, tmp_path)
+
+    assert not outside_file.exists()
+
+
+def test_safe_extractall_keeps_absolute_paths_inside_destination(tmp_path):
+    outside_file = tmp_path.parent / "absolute.txt"
+
+    with tarfile.open(fileobj=_tar_with_file(str(outside_file)), mode="r") as tar:
+        safe_extractall(tar, tmp_path)
+
+    assert not outside_file.exists()
+    assert (tmp_path / str(outside_file).lstrip("/")).read_bytes() == b"contents"
+
+
+def test_safe_extractall_rejects_symlinks_outside_destination(tmp_path):
+    outside_file = tmp_path.parent / "linked.txt"
+
+    with tarfile.open(fileobj=_tar_with_symlink("submission/link", "../../linked.txt"), mode="r") as tar:
+        with pytest.raises(tarfile.TarError):
+            safe_extractall(tar, tmp_path)
+
+    assert not outside_file.exists()


### PR DESCRIPTION
## Summary
- Add a `safe_extractall` helper for PaperBench tar archives.
- Use it when grading local submissions and when `run_monitor` extracts the latest `submission.tar.gz`.
- Add focused coverage for regular extraction, path traversal rejection, absolute-path normalization, and symlink escape rejection.

## Why
PaperBench processes tarballs produced by agent submissions and checkpoints. Raw `extractall` can allow archive members such as `../escaped.txt` to write outside the intended temporary directory on unsafe tarfile defaults. This keeps those extraction paths bounded before judge or monitor processing.

## Validation
- `uv run python -m pytest tests/unit/test_tar_utils.py -q`
- `uv run ruff check paperbench/tar_utils.py tests/unit/test_tar_utils.py paperbench/grade.py paperbench/scripts/run_monitor.py`
- `python3 -m compileall project/paperbench/paperbench/tar_utils.py`
- `git diff --check`

## Limitations
- This hardens local tar extraction paths only; extraction performed inside remote/container utilities is not changed here.

/claim https://algora.io/PrimeIntellect-ai/bounties/RyPmLNGKSWA9D5yJ
