### PR TITLE
Fix MCQ final-answer parsing and multi-answer fallback contract

### DIFF
--- a/project/common/nanoeval/nanoeval/solvers/mcq_api.py
+++ b/project/common/nanoeval/nanoeval/solvers/mcq_api.py
@@ -54,16 +54,18 @@ class OpenAIAPIMCQSolver(MCQSolver[Answer]):
             r"Answer[\s\*]*:[\s\*]*[\(\$]*([" + answer_keys_pattern + "])[)$]*"
         )
         multiple_choice_pattern = re.compile(
-            r"Answer[\s\*]*:[\s\*]*([" + answer_keys_pattern + r"\s,]*)"
+            r"Answer[\s\*]*:[\s\*]*([" + answer_keys_pattern + r" \t,]*)"
         )
 
         if allow_multiple_choices:
-            match = multiple_choice_pattern.search(sampled)
-            if match:
+            matches = list(multiple_choice_pattern.finditer(sampled))
+            if matches:
+                match = matches[-1]
                 picked_letters = set(re.findall("[" + answer_keys_pattern + "]", match.group(1)))
         else:
-            match = single_choice_pattern.search(sampled)
-            if match:
+            matches = list(single_choice_pattern.finditer(sampled))
+            if matches:
+                match = matches[-1]
                 picked_letters = {match.group(1)}
 
         return picked_letters.intersection(answer_keys)
@@ -72,6 +74,13 @@ class OpenAIAPIMCQSolver(MCQSolver[Answer]):
     def _random_guess(question: Question) -> Answer:
         # choose a random answer
         integer_picked = random.choice(range(len(question.answers)))
+        if question.allow_multiple_choices:
+            picked = {integer_picked}
+            return Answer(
+                picked=picked,
+                correct=picked == question.correct_indices,
+                metadata={"random_guess": True},
+            )
         return Answer(
             picked=integer_picked,
             correct=integer_picked in question.correct_indices,

--- a/project/common/nanoeval/nanoeval/solvers/mcq_api_test.py
+++ b/project/common/nanoeval/nanoeval/solvers/mcq_api_test.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import chz
+from nanoeval.solvers.mcq import Answer, MCQEval, MCQSolver, MCQTask, Question
+from nanoeval.solvers.mcq_api import OpenAIAPIMCQSolver
+
+
+@chz.chz
+class DummySolver(MCQSolver[Answer]):
+    async def solve(self, task: MCQTask) -> Answer:  # type: ignore
+        raise AssertionError("not used")
+
+
+@chz.chz
+class ConcreteMCQEval(MCQEval):
+    async def _get_tasks(self) -> list[Question]:  # type: ignore
+        raise AssertionError("not used")
+
+
+def test_extract_picked_letters_uses_final_single_answer() -> None:
+    sampled = "Answer: A\nAfter checking the reasoning, I need to correct this.\nAnswer: B"
+
+    picked = OpenAIAPIMCQSolver._extract_picked_letters(
+        sampled, {"A", "B", "C", "D"}, allow_multiple_choices=False
+    )
+
+    assert picked == {"B"}
+
+
+def test_extract_picked_letters_uses_final_multi_answer() -> None:
+    sampled = "Answer: A, C\nAfter checking the reasoning, I need to correct this.\nAnswer: B, D"
+
+    picked = OpenAIAPIMCQSolver._extract_picked_letters(
+        sampled, {"A", "B", "C", "D"}, allow_multiple_choices=True
+    )
+
+    assert picked == {"B", "D"}
+
+
+def test_extract_picked_letters_handles_adjacent_multi_answer_correction() -> None:
+    sampled = "Answer: A, C\nAnswer: B, D"
+
+    picked = OpenAIAPIMCQSolver._extract_picked_letters(
+        sampled, {"A", "B", "C", "D"}, allow_multiple_choices=True
+    )
+
+    assert picked == {"B", "D"}
+
+
+@pytest.mark.asyncio
+async def test_multi_answer_random_guess_satisfies_eval_contract() -> None:
+    question = Question(
+        question="Pick all that apply.",
+        answers=["alpha", "beta", "gamma", "delta"],
+        correct_indices={0, 2},
+        allow_multiple_choices=True,
+    )
+    task = MCQTask(question=question, question_id="q.0", attempt_id=0)
+
+    answer = OpenAIAPIMCQSolver._random_guess(question)
+
+    assert isinstance(answer.picked, set)
+    assert len(answer.picked) == 1
+    assert answer.correct == (answer.picked == question.correct_indices)
+    assert answer.metadata == {"random_guess": True}
+
+    eval_instance = ConcreteMCQEval(solver=DummySolver())
+    summary: dict[str, Any] = await eval_instance.get_full_summary([(task, answer)])
+    assert "accuracy" in summary
+
+
+def test_single_answer_random_guess_keeps_int_contract() -> None:
+    question = Question(
+        question="Pick one.",
+        answers=["alpha", "beta"],
+        correct_indices={0},
+        allow_multiple_choices=False,
+    )
+
+    answer = OpenAIAPIMCQSolver._random_guess(question)
+
+    assert isinstance(answer.picked, int)
+    assert answer.correct == (answer.picked in question.correct_indices)
+    assert answer.metadata == {"random_guess": True}


### PR DESCRIPTION
## Summary

Fix two correctness issues in `OpenAIAPIMCQSolver`:

- use the final valid `Answer:` declaration when a model self-corrects, instead of the first one;
- keep parse-failure random guesses type-correct for `allow_multiple_choices=True` by returning a singleton `set[int]` and grading it by set equality.

For multi-answer extraction, the answer payload pattern no longer consumes newlines. This allows adjacent corrections such as `Answer: A, C\nAnswer: B, D` to be recognized as two declarations so the later one can win.

Fixes #124.
Fixes #125.

## Regression coverage

Adds focused tests for:

- final single-answer declaration precedence;
- final multi-answer declaration precedence;
- adjacent multi-answer corrections;
- multi-answer random-guess compatibility with the evaluator contract and summary path;
- unchanged single-answer random-guess typing.

## Scope

This is intentionally separate from #120, which addresses successfully parsed multi-answer grading. This change covers parse-failure contract correctness and final-declaration selection without duplicating that PR's grading changes.