### PR TITLE
Fix SWE-Lancer user-tool Playwright trace export

### DIFF
--- a/project/swelancer/issues/16912_4/user_tool.py
+++ b/project/swelancer/issues/16912_4/user_tool.py
@@ -72,8 +72,7 @@ def test_unknown_user_profile_load_offline():
         # Optionally log or handle the exception here
         raise e
     finally:
-        # Ensure the trace is stopped and exported, even if the test fails
-        context.tracing.stop()
-        context.tracing.export(trace_path)
+        # Stop tracing and write the trace archive in one supported Playwright call.
+        context.tracing.stop(path=trace_path)
         # Call the trace cleaner on the saved trace
         trace_cleaner(trace_path)

--- a/project/swelancer/issues/17387_1/user_tool.py
+++ b/project/swelancer/issues/17387_1/user_tool.py
@@ -77,10 +77,9 @@ def test_expensify_17387():
             # Optionally log the error if needed
             print(f"An error occurred: {e}")
         finally:
-            # Stop tracing and export
-            context.tracing.stop()
+            # Stop tracing and write the trace archive in one supported Playwright call.
             trace_path = "/app/expensify/user_tool/output_browser1.zip"
-            context.tracing.export(path=trace_path)
+            context.tracing.stop(path=trace_path)
             # Clean the trace
             trace_cleaner(trace_path)
 

--- a/project/swelancer/issues/29854_602/user_tool.py
+++ b/project/swelancer/issues/29854_602/user_tool.py
@@ -73,6 +73,7 @@ async def test_the_issue(page):
     """
     # Start Playwright trace recording
     await page.context.tracing.start(screenshots=True, snapshots=True, sources=True)
+    trace_path = "/app/expensify/user_tool/output_browser1.zip"
     try:
         await page.goto(NEWDOT_URL)
 
@@ -129,8 +130,7 @@ async def test_the_issue(page):
         LOGGER.error(f"Test failed with error: {e}")
         raise e
     finally:
-        # Stop tracing and export
-        await page.context.tracing.stop()
-        await page.context.tracing.export(path="/app/expensify/user_tool/output_browser1.zip")
+        # Stop tracing and write the trace archive in one supported Playwright call.
+        await page.context.tracing.stop(path=trace_path)
         # Clean the trace
-        trace_cleaner("/app/expensify/user_tool/output_browser1.zip")
+        trace_cleaner(trace_path)


### PR DESCRIPTION
## Summary

Fix the three SWE-Lancer `user_tool.py` flows that call the removed Playwright `Tracing.export()` API.

Playwright writes a trace archive through `tracing.stop(path=...)`. These user tools currently stop tracing first and then call `export()`, which does not exist in the pinned Playwright version and causes the diagnostic user-tool run to fail while saving its trace.

This change updates all three remaining occurrences to stop tracing and write the archive in the same supported call, then runs the existing trace cleaner on that archive.

Fixes #99.

## Changed flows

- `16912_4`
- `17387_1`
- `29854_602`

Both synchronous and asynchronous Playwright forms are handled with their corresponding `stop(path=...)` call.

## Scope

The patch is limited to trace finalization. The task flows, assertions, trace options, output locations, and trace-cleaning behavior are unchanged.

The SWE-Lancer DummySolver explicitly supports executing these user tools through `test_user_tool`, so the fix preserves that documented validation path.