### PR TITLE
Fix SWE-Lancer zipcode consistency grading

### DIFF
--- a/project/swelancer/issues/16912_4/test.py
+++ b/project/swelancer/issues/16912_4/test.py
@@ -39,6 +39,15 @@ def launch_browser(trace_enabled: bool = False):
     return playwright, browser, context, page
 
 
+def _zipcode_hint_style(page_text: str) -> str:
+    normalized = page_text.lower()
+    has_example = "e.g." in normalized
+    has_format = "format" in normalized
+    assert has_example or has_format, "Zip code hint must contain either 'e.g.' or 'format'"
+    assert not (has_example and has_format), "Zip code hint style is ambiguous"
+    return "e.g." if has_example else "format"
+
+
 def test_unknown_user_profile_load_offline(pytestconfig):
     trace_enabled = pytestconfig.getoption("--user-tool-trace")
 
@@ -68,9 +77,7 @@ def test_unknown_user_profile_load_offline(pytestconfig):
         page.wait_for_timeout(1000)
 
         address_text = page.get_by_test_id("AddressPage").inner_text()
-        assert "e.g." in address_text, (
-            "Zip code hint does not begin with 'e.g.' on profile > address"
-        )
+        address_hint_style = _zipcode_hint_style(address_text)
 
         page.get_by_label("Back").last.click()
         page.get_by_test_id("InitialSettingsPage").get_by_label("Workspaces").click()
@@ -79,8 +86,9 @@ def test_unknown_user_profile_load_offline(pytestconfig):
         page.get_by_label("Connect bank account").click()
 
         personal_info_text = page.locator('div[data-testid="PersonalInfo"]').inner_text()
-        assert "e.g." in personal_info_text, (
-            "Zip code hint does not begin with 'e.g.' on connect bank account > address"
+        bank_hint_style = _zipcode_hint_style(personal_info_text)
+        assert bank_hint_style == address_hint_style, (
+            "Zip code hint must use the same style on profile and connect bank account pages"
         )
 
     finally:


### PR DESCRIPTION
## Summary

Make SWE-Lancer sample `16912_4` grade the consistency requirement stated by the task itself.

The task accepts either zipcode-hint convention as long as the profile-address page and connect-bank-account page use the same convention. The current test requires `e.g.` on both pages, so a valid solution that consistently uses `Format` fails.

This change determines whether each page uses `e.g.` or `format` and then requires the two pages to match.

Fixes #100.

## Behavior

The grader now accepts:

- `e.g.` on both pages
- `format` on both pages

and rejects mixed conventions.

Each inspected page must still expose one of the two expected hint styles, so the test does not become a generic presence check.

## Scope

Only the runtime grading test for `16912_4` is changed. The issue's separate legacy `user_tool.py` tracing problem is handled independently under #99 so the two fixes do not overlap.