### PR TITLE
Record ShortAnswer solver correctness

### DIFF
--- a/project/common/nanoeval/nanoeval/solvers/short_answer.py
+++ b/project/common/nanoeval/nanoeval/solvers/short_answer.py
@@ -78,7 +78,7 @@ class ShortAnswerEval(ABC, Eval[ShortAnswerTask, Answer]):
         res = await self.solver.solve(task)
         await asyncio.to_thread(
             get_recorder().record_match,
-            correct=False,
+            correct=bool(res.is_correct),
             metadata=res.metadata,
         )
         return res

--- a/project/common/nanoeval/nanoeval/solvers/short_answer_test.py
+++ b/project/common/nanoeval/nanoeval/solvers/short_answer_test.py
@@ -1,0 +1,75 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+import chz
+import nanoeval.solvers.short_answer as short_answer_module
+from nanoeval.solvers.short_answer import (
+    Answer,
+    Question,
+    ShortAnswerEval,
+    ShortAnswerSolver,
+    ShortAnswerTask,
+)
+
+
+@chz.chz
+class FixedCorrectnessSolver(ShortAnswerSolver):
+    is_correct: bool | None
+
+    async def solve(self, task: ShortAnswerTask) -> Answer:
+        return Answer(
+            answer="sampled answer",
+            is_correct=self.is_correct,
+            metadata={"source": "test"},
+        )
+
+
+@chz.chz
+class ConcreteShortAnswerEval(ShortAnswerEval):
+    async def _get_tasks(self) -> list[Question]:
+        return []
+
+
+@pytest.mark.asyncio
+async def test_evaluate_records_explicit_correctness(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder = MagicMock()
+    monkeypatch.setattr(short_answer_module, "get_recorder", lambda: recorder)
+
+    eval_instance = ConcreteShortAnswerEval(solver=FixedCorrectnessSolver(is_correct=True))
+    task = ShortAnswerTask(
+        question=Question(question="test question"),
+        question_id="short-answer.0",
+        attempt_id=0,
+    )
+
+    result = await eval_instance.evaluate(task)
+
+    assert result.is_correct is True
+    recorder.record_match.assert_called_once_with(
+        correct=True,
+        metadata={"source": "test"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_evaluate_keeps_ungraded_samples_recorder_safe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorder = MagicMock()
+    monkeypatch.setattr(short_answer_module, "get_recorder", lambda: recorder)
+
+    eval_instance = ConcreteShortAnswerEval(solver=FixedCorrectnessSolver(is_correct=None))
+    task = ShortAnswerTask(
+        question=Question(question="test question"),
+        question_id="short-answer.0",
+        attempt_id=0,
+    )
+
+    result = await eval_instance.evaluate(task)
+
+    assert result.is_correct is None
+    recorder.record_match.assert_called_once_with(
+        correct=False,
+        metadata={"source": "test"},
+    )


### PR DESCRIPTION
## Summary

Make `ShortAnswerEval.evaluate()` record the correctness supplied by the solver instead of hard-coding every sample as incorrect.

`Answer.is_correct` is already the field used by `ShortAnswerEval.get_summary()`. Before this change, a solver could return `is_correct=True`, the aggregate summary could count the sample as correct, and the recorder would still store `correct=False` for the same sample.

Fixes #127.

## Fix

Use `bool(res.is_correct)` for the recorder's required boolean `correct` field.

This preserves explicit `True` and `False` solver grades. The existing ungraded `None` state remains recorder-safe by mapping to `False`, while the returned `Answer` itself is left unchanged.

## Regression coverage

Adds focused async tests verifying that:

- an explicitly correct solver result is recorded with `correct=True`;
- an ungraded `is_correct=None` result remains unchanged on the returned answer while the recorder receives a valid boolean `False`.

No summary or task-generation behavior changes.