### PR TITLE
Fix computer-task action limit boundary

### DIFF
--- a/project/common/nanoeval/nanoeval/solvers/computer_tasks/limits.py
+++ b/project/common/nanoeval/nanoeval/solvers/computer_tasks/limits.py
@@ -82,7 +82,7 @@ class LimitsHelper:
                 nonlocal num_actions
                 num_actions += 1
 
-                if num_actions >= self.max_actions:
+                if num_actions > self.max_actions:
                     raise ActionLimitExceededError("Exceeded max actions = %d!" % self.max_actions)
 
             yield increment_actions

--- a/project/common/nanoeval/nanoeval/solvers/computer_tasks/limits_test.py
+++ b/project/common/nanoeval/nanoeval/solvers/computer_tasks/limits_test.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from nanoeval.solvers.computer_tasks.limits import LimitsHelper
+from nanoeval.solvers.computer_tasks.limits import ActionLimitExceededError, LimitsHelper
 from nanoeval.solvers.computer_tasks.pausable_timer import NamedTimeoutError
 
 
@@ -21,3 +21,14 @@ async def test_unrelated_timeouts() -> None:
         async with limits.enforce_timeout("test", 0.01):
             async with asyncio.timeout(0.5):
                 await asyncio.sleep(1)
+
+
+@pytest.mark.asyncio
+async def test_rollout_action_limit_allows_exact_maximum() -> None:
+    limits = LimitsHelper(max_actions=2)
+
+    async with limits.enforce_rollout_limits() as increment_actions:
+        increment_actions()
+        increment_actions()
+        with pytest.raises(ActionLimitExceededError, match="Exceeded max actions = 2"):
+            increment_actions()


### PR DESCRIPTION
## Summary

Allow a computer-task rollout to use exactly the configured number of actions before raising `ActionLimitExceededError`.

`LimitsHelper.enforce_rollout_limits()` currently increments the counter and raises when `num_actions >= max_actions`. A configured limit of 100 therefore rejects action 100 and permits only 99 actions, despite the helper documenting that the error is raised when the count **exceeds** the maximum.

Fixes #131.

## Fix

Raise when `num_actions > max_actions`.

## Regression coverage

Adds a boundary test with `max_actions=2` verifying that:

- action 1 succeeds;
- action 2 succeeds;
- action 3 raises `ActionLimitExceededError`.

The timeout behavior, action counter initialization, exception type, and error message are unchanged.