### PR TITLE
Use canonical correctness in end-of-run computer-task logging

### DIFF
--- a/project/common/nanoeval/nanoeval/solvers/computer_tasks/solver.py
+++ b/project/common/nanoeval/nanoeval/solvers/computer_tasks/solver.py
@@ -175,7 +175,6 @@ def _log_results(task: ComputerTask, result: FinalResult) -> None:
     """
     recorder = get_recorder()
 
-    score = result.grade.score
     log = result.grade.grader_log
 
     recorder.record_sampling(
@@ -186,7 +185,7 @@ def _log_results(task: ComputerTask, result: FinalResult) -> None:
     )
 
     recorder.record_match(
-        correct=bool(score),
+        correct=result.correct,
         group_id=str(task.attempt_id),
     )
 

--- a/project/common/nanoeval/nanoeval/solvers/computer_tasks/solver_test.py
+++ b/project/common/nanoeval/nanoeval/solvers/computer_tasks/solver_test.py
@@ -1,0 +1,29 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import nanoeval.solvers.computer_tasks.solver as solver_module
+from nanoeval.solvers.computer_tasks.solver import _log_results
+from nanoeval.solvers.computer_tasks.steps import FinalResult
+from nanoeval.solvers.computer_tasks.task import Grade
+
+
+def test_log_results_uses_final_result_correctness(monkeypatch) -> None:
+    recorder = MagicMock()
+    monkeypatch.setattr(solver_module, "get_recorder", lambda: recorder)
+    task = SimpleNamespace(question_id="task.0", attempt_id=3)
+    result = FinalResult(grade=Grade(score=0.5, grader_log="partial credit"))
+
+    assert result.correct is False
+
+    _log_results(task, result)
+
+    recorder.record_sampling.assert_called_once_with(
+        prompt="",
+        sampled="partial credit",
+        sample_id="task.0",
+        group_id="3",
+    )
+    recorder.record_match.assert_called_once_with(
+        correct=False,
+        group_id="3",
+    )


### PR DESCRIPTION
## Summary

Make the optional end-of-run computer-task logger use the same correctness definition as `FinalResult` and the normal evaluation recording path.

`FinalResult.correct` is true only when `grade.score == 1`, but `_log_results()` currently calls `bool(score)`. Any positive partial score such as `0.5` is therefore recorded as fully correct when `log_at_end=True` even though the result itself is incorrect.

Fixes #133.

## Fix

Record `result.correct` directly and remove the now-unused local score variable.

## Regression coverage

Adds a focused recorder test with `grade.score=0.5` verifying that:

- `FinalResult.correct` is false;
- the end-of-run sample log is preserved;
- `record_match()` receives `correct=False`.

The grade value, grader log, group IDs, normal `_evaluate_inner()` recording path, and continuous-score data are unchanged.