### PR TITLE
Avoid mutating conversations while stripping recorder metadata

### DIFF
--- a/project/common/nanoeval/nanoeval/solvers/computer_tasks/metadata_strip_test.py
+++ b/project/common/nanoeval/nanoeval/solvers/computer_tasks/metadata_strip_test.py
@@ -1,0 +1,31 @@
+from pydantic import BaseModel
+
+from nanoeval.solvers.computer_tasks.solver import strip_all_metadata
+
+
+class TestMessage(BaseModel):
+    metadata: dict[str, object]
+
+
+class TestConversation(BaseModel):
+    metadata: dict[str, object]
+    messages: list[TestMessage]
+
+
+def test_strip_all_metadata_does_not_mutate_original_conversation() -> None:
+    original = TestConversation(
+        metadata={"keep": "conversation", "drop": "secret"},
+        messages=[
+            TestMessage(metadata={"keep": "message", "drop": "secret"}),
+        ],
+    )
+
+    stripped = strip_all_metadata(original, allowed_metadata_fields=["keep"])
+
+    assert stripped is not original
+    assert stripped.messages[0] is not original.messages[0]  # type: ignore[attr-defined]
+    assert stripped.metadata == {"keep": "conversation"}  # type: ignore[attr-defined]
+    assert stripped.messages[0].metadata == {"keep": "message"}  # type: ignore[attr-defined]
+
+    assert original.metadata == {"keep": "conversation", "drop": "secret"}
+    assert original.messages[0].metadata == {"keep": "message", "drop": "secret"}

--- a/project/common/nanoeval/nanoeval/solvers/computer_tasks/solver.py
+++ b/project/common/nanoeval/nanoeval/solvers/computer_tasks/solver.py
@@ -82,9 +82,10 @@ def strip_all_metadata(
     if allowed_metadata_fields is None:
         allowed_metadata_fields = []
     convo = convo.model_copy(
+        deep=True,
         update={
             "metadata": {k: v for k, v in convo.metadata.items() if k in allowed_metadata_fields}  # type: ignore
-        }
+        },
     )
     for msg in convo.messages:  # type: ignore
         msg.metadata = {k: v for k, v in msg.metadata.items() if k in allowed_metadata_fields}


### PR DESCRIPTION
## Summary

Make computer-task metadata stripping operate on an independent conversation copy instead of mutating message objects shared with the source conversation.

`strip_all_metadata()` currently uses Pydantic's shallow `model_copy()` and then rewrites each copied message's `metadata`. Because the copied conversation shares its message objects with the original, logging can remove metadata from the live/final conversation it is supposed to serialize.

Fixes #134.

## Fix

Use `model_copy(deep=True, ...)` before filtering message metadata. The existing conversation-level and message-level allow-list behavior is unchanged.

## Regression coverage

Adds a focused Pydantic regression verifying that:

- the stripped conversation is a different object;
- its message object is also independent;
- disallowed conversation and message metadata are removed from the stripped copy;
- the original conversation and original message metadata remain unchanged.

No recorder schema or metadata filtering policy changes.