### PR TITLE
Validate per-instance rollout counts after system errors

### DIFF
--- a/project/common/nanoeval/nanoeval/metrics/standard.py
+++ b/project/common/nanoeval/nanoeval/metrics/standard.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import Counter
 from typing import Any, Awaitable, Callable, Sequence, cast
 
 import pandas as pd
@@ -147,18 +148,20 @@ async def handle_system_errors_and_compute_metrics(
         )
         for task, result in results
     ]
-    task_ids_including_errors = {
+    rollout_counts_including_errors = Counter(
         task.question_id for task, _ in results_treating_system_errors_as_fails
-    }
+    )
+    task_ids_including_errors = set(rollout_counts_including_errors)
 
     results_excluding_errors = [
         (task, result) for task, result in results if not isinstance(result, RolloutSystemError)
     ]
-    task_ids_excluding_errors = {task.question_id for task, _ in results_excluding_errors}
+    rollout_counts_excluding_errors = Counter(task.question_id for task, _ in results_excluding_errors)
+    task_ids_excluding_errors = set(rollout_counts_excluding_errors)
 
     summary = {
         **(await metrics_fn(results_excluding_errors)),
-        "is_valid": len(task_ids_including_errors) == len(task_ids_excluding_errors),
+        "is_valid": rollout_counts_including_errors == rollout_counts_excluding_errors,
         "num_tasks": len(task_ids_excluding_errors),
     }
 

--- a/project/common/nanoeval/nanoeval/metrics/standard_test.py
+++ b/project/common/nanoeval/nanoeval/metrics/standard_test.py
@@ -1,12 +1,15 @@
 import math
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pandas as pd
 import pytest
 
+from nanoeval.eval import RolloutSystemError
 from nanoeval.metrics.standard import (
     compute_default_metrics,
     compute_default_metrics_on_correctness_without_answer_groups,
+    handle_system_errors_and_compute_metrics,
 )
 
 
@@ -133,3 +136,48 @@ def test_compute_metrics_on_correctness_without_answer_groups(
     metrics = compute_default_metrics_on_correctness_without_answer_groups(pd.DataFrame(data))
     for key, value in expected.items():
         assert math.isclose(cast(float, metrics[key]), value)
+
+
+async def _count_metrics(results: list[tuple[Any, Any]]) -> dict[str, int]:
+    return {"count": len(results)}
+
+
+def _process_invalid(task: Any) -> bool:
+    del task
+    return False
+
+
+@pytest.mark.asyncio
+async def test_partial_instance_system_error_marks_top_level_metrics_invalid() -> None:
+    task0 = SimpleNamespace(question_id="q0", attempt_id=0)
+    task1 = SimpleNamespace(question_id="q0", attempt_id=1)
+
+    summary = await handle_system_errors_and_compute_metrics(
+        _count_metrics,
+        [
+            (task0, True),
+            (task1, RolloutSystemError("worker failed")),
+        ],
+        _process_invalid,
+    )
+
+    assert summary["count"] == 1
+    assert summary["num_tasks"] == 1
+    assert summary["is_valid"] is False
+    assert summary["metrics_including_errors"]["count"] == 2
+    assert summary["metrics_including_errors"]["num_tasks"] == 1
+
+
+@pytest.mark.asyncio
+async def test_complete_multi_attempt_instance_remains_valid() -> None:
+    task0 = SimpleNamespace(question_id="q0", attempt_id=0)
+    task1 = SimpleNamespace(question_id="q0", attempt_id=1)
+
+    summary = await handle_system_errors_and_compute_metrics(
+        _count_metrics,
+        [(task0, True), (task1, False)],
+        _process_invalid,
+    )
+
+    assert summary["count"] == 2
+    assert summary["is_valid"] is True


### PR DESCRIPTION
## Summary

Make the top-level system-error validity flag account for missing rollout attempts within an instance, rather than only checking whether each question ID is still represented.

`handle_system_errors_and_compute_metrics()` documents metrics as potentially invalid when an excluded system error leaves too few rollouts for an instance. The current `is_valid` check compares sets of question IDs, so one failed attempt out of a multi-attempt question still reports `is_valid=True` as long as another attempt survives.

Fixes #137.

## Fix

Compare `Counter` values of rollouts per `question_id` before and after excluding system errors. Top-level metrics are valid only when every instance retains the same rollout count.

The existing distinct task-ID sets are still used for `num_tasks` and the metrics-including-errors bookkeeping.

## Regression coverage

Extends the existing standard-metrics tests with:

- one question with two attempts where one attempt is a system error, which must produce `is_valid=False`;
- a two-attempt all-success control, which remains valid;
- checks that metrics including errors still receive both attempts.

Metric computation itself and system-error failure substitution are unchanged.