### PR TITLE
Load legacy PaperBench reproduction metadata with optional defaults

### DIFF
--- a/project/paperbench/paperbench/nano/structs.py
+++ b/project/paperbench/paperbench/nano/structs.py
@@ -50,7 +50,9 @@ class ReproductionMetadata:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ReproductionMetadata:
         try:
-            retried_results = [ReproScriptRunOutcome.from_dict(r) for r in data["retried_results"]]
+            retried_results = [
+                ReproScriptRunOutcome.from_dict(r) for r in data.get("retried_results", [])
+            ]
 
             return cls(
                 is_valid_git_repo=data["is_valid_git_repo"],
@@ -61,9 +63,9 @@ class ReproductionMetadata:
                 timedout=data["timedout"],
                 repro_log=data["repro_log"],
                 retried_results=retried_results,
-                repro_execution_time=data["repro_execution_time"],
-                git_status_after_reproduce=data["git_status_after_reproduce"],
-                executed_submission=data["executed_submission"],
+                repro_execution_time=data.get("repro_execution_time"),
+                git_status_after_reproduce=data.get("git_status_after_reproduce"),
+                executed_submission=data.get("executed_submission"),
             )
         except KeyError as e:
             raise ValueError("Missing required field in reproduction metadata") from e

--- a/project/paperbench/tests/unit/test_structs.py
+++ b/project/paperbench/tests/unit/test_structs.py
@@ -1,0 +1,46 @@
+from paperbench.nano.structs import ReproductionMetadata
+
+
+def _legacy_metadata() -> dict:
+    return {
+        "is_valid_git_repo": True,
+        "git_log": "commit",
+        "repro_script_exists": True,
+        "files_before_reproduce": "before",
+        "files_after_reproduce": "after",
+        "timedout": False,
+        "repro_log": "ok",
+    }
+
+
+def test_reproduction_metadata_loads_legacy_optional_schema() -> None:
+    metadata = ReproductionMetadata.from_dict(_legacy_metadata())
+
+    assert metadata.retried_results == []
+    assert metadata.repro_execution_time is None
+    assert metadata.git_status_after_reproduce is None
+    assert metadata.executed_submission is None
+
+
+def test_reproduction_metadata_preserves_optional_fields_when_present() -> None:
+    data = {
+        **_legacy_metadata(),
+        "retried_results": [
+            {
+                "repro_execution_time": 12.5,
+                "timedout": False,
+                "repro_log": "retry ok",
+            }
+        ],
+        "repro_execution_time": 20.0,
+        "git_status_after_reproduce": "clean",
+        "executed_submission": "/tmp/submission.tar.gz",
+    }
+
+    metadata = ReproductionMetadata.from_dict(data)
+
+    assert len(metadata.retried_results) == 1
+    assert metadata.retried_results[0].repro_execution_time == 12.5
+    assert metadata.repro_execution_time == 20.0
+    assert metadata.git_status_after_reproduce == "clean"
+    assert metadata.executed_submission == "/tmp/submission.tar.gz"


### PR DESCRIPTION
## Summary

Keep cached PaperBench reproduction metadata loadable when it was written before newer optional fields were added.

`ReproductionMetadata` already declares `retried_results` with an empty-list default and three fields as optional, but `from_dict()` indexes all four keys directly. Reusing an older `*_executed_metadata.json` can therefore raise `ValueError` even though the dataclass has well-defined defaults for the missing fields.

Fixes #142.

## Fix

- default missing `retried_results` to `[]`;
- load `repro_execution_time`, `git_status_after_reproduce`, and `executed_submission` with `dict.get()`;
- keep the core reproduction fields required as before.

## Regression coverage

Adds tests verifying that:

- a legacy dictionary containing only the core required fields loads successfully with the dataclass defaults;
- newer optional fields and retried-run metadata are preserved when present.

Serialization output and the required core metadata schema are unchanged.