### PR TITLE
Fix SWE-Lancer token usage totals

### DIFF
--- a/project/swelancer/swelancer/eval.py
+++ b/project/swelancer/swelancer/eval.py
@@ -477,6 +477,7 @@ class SWELancerEval(PythonCodingEval):
         )
         tasks = pd.read_csv(PATH_TO_SWE_LANCER_TASKS)
         tasks["proposals"] = tasks["proposals"].fillna("")  # pandas reads empty as float nan
+
         if self.split != "all":
             tasks = tasks[tasks["set"] == self.split]
 

--- a/project/swelancer/swelancer/eval.py
+++ b/project/swelancer/swelancer/eval.py
@@ -477,7 +477,6 @@ class SWELancerEval(PythonCodingEval):
         )
         tasks = pd.read_csv(PATH_TO_SWE_LANCER_TASKS)
         tasks["proposals"] = tasks["proposals"].fillna("")  # pandas reads empty as float nan
-
         if self.split != "all":
             tasks = tasks[tasks["set"] == self.split]
 
@@ -608,9 +607,9 @@ class SWELancerEval(PythonCodingEval):
         )
         summary["length_stats"] = self._get_convo_len_stats(results)
 
-        summary["total_input_tokens"] = 1
-        summary["total_output_tokens"] = 1
-        summary["total_reasoning_tokens"] = 1
+        summary["total_input_tokens"] = 0
+        summary["total_output_tokens"] = 0
+        summary["total_reasoning_tokens"] = 0
         for _task, result in results:
             if isinstance(result, FinalResult):
                 try:

--- a/project/swelancer/tests/test_token_totals.py
+++ b/project/swelancer/tests/test_token_totals.py
@@ -1,0 +1,23 @@
+import asyncio
+from types import SimpleNamespace
+from typing import Any, cast
+
+from swelancer.eval import SWELancerEval
+
+
+def test_empty_summary_reports_zero_token_totals(tmp_path) -> None:
+    run_group_id = "token-total-regression"
+    (tmp_path / run_group_id).mkdir()
+    eval_stub = SimpleNamespace(
+        runs_dir=str(tmp_path),
+        run_group_id=run_group_id,
+        _get_convo_len_stats=lambda results: {},
+    )
+
+    summary = asyncio.run(
+        SWELancerEval.get_full_summary(cast(Any, eval_stub), [])
+    )
+
+    assert summary["total_input_tokens"] == 0
+    assert summary["total_output_tokens"] == 0
+    assert summary["total_reasoning_tokens"] == 0


### PR DESCRIPTION
## Summary

Remove the phantom one-token offset from SWE-Lancer aggregate usage metrics.

`SWELancerEval.get_full_summary()` currently initializes each aggregate token counter to `1` before adding the per-result grader usage. Every run therefore reports one extra input, output, and reasoning token, including an empty run.

Fixes #139.

## Fix

Initialize `total_input_tokens`, `total_output_tokens`, and `total_reasoning_tokens` to zero before accumulation.

## Regression coverage

Adds a focused empty-summary regression verifying all three aggregate token totals are exactly zero when no results are present.

Per-result token extraction, `results.csv` contents, earned-value aggregation, and grading behavior are unchanged.