### PR TITLE
Preserve PaperBench run group identity when aggregating seeds

### DIFF
--- a/project/paperbench/paperbench/metrics.py
+++ b/project/paperbench/paperbench/metrics.py
@@ -50,10 +50,19 @@ class ParsedEntry:
     """Contains parsed JSONL entry data"""
 
     agent_id: str
+    run_group_id: str
     paper_id: str
     paper_run_id: str
     timestamp: float
     graded_task_tree: GradedTaskNode
+
+
+@dataclass
+class RunGroupRecords:
+    """Paper evaluations belonging to one actual nanoeval run group."""
+
+    timestamp: float
+    paper_evaluations: dict[str, tuple[PaperEvaluation, float]]
 
 
 def compute_ars(
@@ -163,6 +172,27 @@ def parse_disqualified_runs(disqualification_data_path: Path) -> set[str]:
         return {line.strip() for line in f}
 
 
+def _build_evaluation_runs(
+    run_groups: dict[str, RunGroupRecords], seeds_to_keep: int | None
+) -> list[EvaluationRun]:
+    sorted_run_groups = sorted(
+        run_groups.items(), key=lambda item: item[1].timestamp, reverse=True
+    )
+    if seeds_to_keep is not None:
+        sorted_run_groups = sorted_run_groups[:seeds_to_keep]
+
+    return [
+        EvaluationRun(
+            seed=run_group_id,
+            paper_evaluations={
+                paper_id: paper_eval
+                for paper_id, (paper_eval, _timestamp) in records.paper_evaluations.items()
+            },
+        )
+        for run_group_id, records in sorted_run_groups
+    ]
+
+
 def parse_run_data(
     run_data_path: Path,
     disqualification_data_path: Path | None = None,
@@ -182,7 +212,7 @@ def parse_run_data(
         Dictionary mapping agent IDs to lists of EvaluationRun objects
         where each EvaluationRun contains 1 seed of paper evaluations
     """
-    agent_runs: dict[str, dict[str, list[dict[str, Any]]]] = {}
+    agent_runs: dict[str, dict[str, RunGroupRecords]] = {}
 
     # Helper function since we accidentally changed the format of nanoeval records
     def detect_format(entry: dict[str, Any]) -> Literal["old", "new"] | None:
@@ -237,6 +267,7 @@ def parse_run_data(
 
         return ParsedEntry(
             agent_id=agent_id,
+            run_group_id=run_group_id,
             paper_id=paper_id,
             paper_run_id=paper_run_id,
             timestamp=timestamp,
@@ -259,10 +290,6 @@ def parse_run_data(
                 if parsed_entry is None:
                     continue
 
-                # Initialize agent and seed data structures if needed
-                if parsed_entry.agent_id not in agent_runs:
-                    agent_runs[parsed_entry.agent_id] = {}
-
                 paper_eval = PaperEvaluation(
                     paper_run_id=parsed_entry.paper_run_id,
                     paper_id=parsed_entry.paper_id,
@@ -270,37 +297,24 @@ def parse_run_data(
                 )
                 paper_eval = check_disqualification(paper_eval, disqualified_paper_runs)
 
-                if parsed_entry.paper_id not in agent_runs[parsed_entry.agent_id]:
-                    agent_runs[parsed_entry.agent_id][parsed_entry.paper_id] = []
-
-                agent_runs[parsed_entry.agent_id][parsed_entry.paper_id].append(
-                    {"paper_eval": paper_eval, "timestamp": parsed_entry.timestamp}
+                run_groups = agent_runs.setdefault(parsed_entry.agent_id, {})
+                run_group = run_groups.setdefault(
+                    parsed_entry.run_group_id,
+                    RunGroupRecords(timestamp=parsed_entry.timestamp, paper_evaluations={}),
                 )
+                run_group.timestamp = max(run_group.timestamp, parsed_entry.timestamp)
 
-    # Convert to final format, keeping only the N most recent seeds
-    agent_to_eval_runs: dict[str, list[EvaluationRun]] = {agent: [] for agent in agent_runs.keys()}
+                previous = run_group.paper_evaluations.get(parsed_entry.paper_id)
+                if previous is None or parsed_entry.timestamp >= previous[1]:
+                    run_group.paper_evaluations[parsed_entry.paper_id] = (
+                        paper_eval,
+                        parsed_entry.timestamp,
+                    )
 
-    for agent, paper_data in agent_runs.items():
-        # keep only N most recent seeds
-        filtered_paper_data = {}
-        for paper_id, data in paper_data.items():
-            sorted_data = sorted(data, key=lambda x: x["timestamp"], reverse=True)
-            filtered_paper_data[paper_id] = sorted_data[:seeds_to_keep]
-
-        # then, create the N EvaluationRun objects
-        max_num_seeds = max([len(data) for data in filtered_paper_data.values()])
-        for seed in range(max_num_seeds):
-            eval_run = EvaluationRun(seed=seed, paper_evaluations={})
-            for data in filtered_paper_data.values():
-                # some evaluation runs may not have all papers evaluated
-                if seed == len(data):
-                    continue
-                paper_eval = data[seed]["paper_eval"]
-                eval_run.paper_evaluations[paper_eval.paper_id] = paper_eval
-
-            agent_to_eval_runs[agent].append(eval_run)
-
-    return agent_to_eval_runs
+    return {
+        agent: _build_evaluation_runs(run_groups, seeds_to_keep)
+        for agent, run_groups in agent_runs.items()
+    }
 
 
 if __name__ == "__main__":

--- a/project/paperbench/paperbench/metrics.py
+++ b/project/paperbench/paperbench/metrics.py
@@ -51,6 +51,7 @@ class ParsedEntry:
 
     agent_id: str
     run_group_id: str
+    attempt_id: int | None
     paper_id: str
     paper_run_id: str
     timestamp: float
@@ -59,10 +60,21 @@ class ParsedEntry:
 
 @dataclass
 class RunGroupRecords:
-    """Paper evaluations belonging to one actual nanoeval run group."""
+    """Paper evaluations belonging to one nanoeval attempt within a run group."""
 
     timestamp: float
     paper_evaluations: dict[str, tuple[PaperEvaluation, float]]
+
+
+def _attempt_id_from_recorder_group_id(group_id: Any) -> int | None:
+    """Extract nanoeval's attempt ID from its ``<attempt>.<retry>`` group ID."""
+    if group_id is None:
+        return None
+    attempt_id, _, _retry_idx = str(group_id).partition(".")
+    try:
+        return int(attempt_id)
+    except ValueError:
+        return None
 
 
 def compute_ars(
@@ -173,7 +185,7 @@ def parse_disqualified_runs(disqualification_data_path: Path) -> set[str]:
 
 
 def _build_evaluation_runs(
-    run_groups: dict[str, RunGroupRecords], seeds_to_keep: int | None
+    run_groups: dict[Hashable, RunGroupRecords], seeds_to_keep: int | None
 ) -> list[EvaluationRun]:
     sorted_run_groups = sorted(
         run_groups.items(), key=lambda item: item[1].timestamp, reverse=True
@@ -183,13 +195,13 @@ def _build_evaluation_runs(
 
     return [
         EvaluationRun(
-            seed=run_group_id,
+            seed=run_key,
             paper_evaluations={
                 paper_id: paper_eval
                 for paper_id, (paper_eval, _timestamp) in records.paper_evaluations.items()
             },
         )
-        for run_group_id, records in sorted_run_groups
+        for run_key, records in sorted_run_groups
     ]
 
 
@@ -212,7 +224,7 @@ def parse_run_data(
         Dictionary mapping agent IDs to lists of EvaluationRun objects
         where each EvaluationRun contains 1 seed of paper evaluations
     """
-    agent_runs: dict[str, dict[str, RunGroupRecords]] = {}
+    agent_runs: dict[str, dict[Hashable, RunGroupRecords]] = {}
 
     # Helper function since we accidentally changed the format of nanoeval records
     def detect_format(entry: dict[str, Any]) -> Literal["old", "new"] | None:
@@ -260,6 +272,7 @@ def parse_run_data(
             )
 
         run_group_id = entry["data"]["run_group_id"]
+        attempt_id = _attempt_id_from_recorder_group_id(entry.get("group_id"))
         paper_run_id = entry["data"]["run_id"]
         agent_id = run_group_id.split("_")[-1]
         paper_id = pb_result["paper_id"]
@@ -268,6 +281,7 @@ def parse_run_data(
         return ParsedEntry(
             agent_id=agent_id,
             run_group_id=run_group_id,
+            attempt_id=attempt_id,
             paper_id=paper_id,
             paper_run_id=paper_run_id,
             timestamp=timestamp,
@@ -298,8 +312,13 @@ def parse_run_data(
                 paper_eval = check_disqualification(paper_eval, disqualified_paper_runs)
 
                 run_groups = agent_runs.setdefault(parsed_entry.agent_id, {})
+                run_key: Hashable = (
+                    (parsed_entry.run_group_id, parsed_entry.attempt_id)
+                    if parsed_entry.attempt_id is not None
+                    else parsed_entry.run_group_id
+                )
                 run_group = run_groups.setdefault(
-                    parsed_entry.run_group_id,
+                    run_key,
                     RunGroupRecords(timestamp=parsed_entry.timestamp, paper_evaluations={}),
                 )
                 run_group.timestamp = max(run_group.timestamp, parsed_entry.timestamp)

--- a/project/paperbench/paperbench/nano/logging.py
+++ b/project/paperbench/paperbench/nano/logging.py
@@ -1,9 +1,13 @@
+from collections.abc import Generator
+from contextlib import contextmanager
+
 import blobfile as bf
 import structlog
 from structlog.typing import EventDict
 from typing_extensions import override
 
 from nanoeval.library_config import LibraryConfig, set_library_config
+from nanoeval.recorder_protocol import RecorderProtocol
 from nanoeval.setup import nanoeval_logging
 from paperbench.utils import get_default_runs_dir
 
@@ -52,6 +56,14 @@ class PaperBenchLibraryConfig(LibraryConfig):
     To be called at the eval entrypoint with
     nanoeval.library_config.set_library_config(PaperBenchLibraryConfig())
     """
+
+    @override
+    @contextmanager
+    def set_recorder_context(
+        self, rec: RecorderProtocol, sample_id: str, group_id: str
+    ) -> Generator[None, None, None]:
+        with rec.as_default_recorder(sample_id, group_id):
+            yield
 
     @override
     def setup_logging(self) -> None:

--- a/project/paperbench/tests/unit/test_metrics.py
+++ b/project/paperbench/tests/unit/test_metrics.py
@@ -1,3 +1,5 @@
+import json
+from pathlib import Path
 from typing import Any, cast
 
 from paperbench.metrics import (
@@ -5,6 +7,8 @@ from paperbench.metrics import (
     RunGroupRecords,
     _attempt_id_from_recorder_group_id,
     _build_evaluation_runs,
+    compute_agg_stats,
+    parse_run_data,
 )
 
 
@@ -14,6 +18,48 @@ def _paper(run_id: str, paper_id: str) -> PaperEvaluation:
         paper_id=paper_id,
         graded_task_node=cast(Any, object()),
     )
+
+
+def _graded_task_tree(score: float) -> dict[str, Any]:
+    return {
+        "id": "root",
+        "requirements": "test",
+        "weight": 1,
+        "sub_tasks": [],
+        "task_category": "Code Development",
+        "score": score,
+        "valid_score": True,
+        "explanation": "test",
+        "judge_metadata": None,
+    }
+
+
+def _write_result(
+    path: Path,
+    *,
+    group_id: str,
+    timestamp: str,
+    paper_id: str,
+    run_id: str,
+    score: float,
+) -> None:
+    entry = {
+        "record_type": "extra",
+        "group_id": group_id,
+        "timestamp": timestamp,
+        "data": {
+            "run_group_id": "2026_run-group_agent",
+            "run_id": run_id,
+            "pb_result": {
+                "paperbench_result": {
+                    "paper_id": paper_id,
+                    "judge_output": {"graded_task_tree": _graded_task_tree(score)},
+                }
+            },
+        },
+    }
+    with path.open("a") as f:
+        f.write(json.dumps(entry) + "\n")
 
 
 def test_evaluation_runs_preserve_actual_run_group_boundaries() -> None:
@@ -83,3 +129,48 @@ def test_attempts_within_one_run_group_remain_distinct() -> None:
 
     assert [run.seed for run in runs] == [("run_A", 1), ("run_A", 0)]
     assert all(set(run.paper_evaluations) == {"paper-a", "paper-b"} for run in runs)
+
+
+def test_parse_run_data_preserves_multiple_attempts_in_one_run_group(tmp_path: Path) -> None:
+    records = tmp_path / "results.jsonl"
+    _write_result(
+        records,
+        group_id="0.0",
+        timestamp="2026-08-17T00:00:00+00:00",
+        paper_id="paper-a",
+        run_id="attempt0-paper-a",
+        score=0.2,
+    )
+    _write_result(
+        records,
+        group_id="0.0",
+        timestamp="2026-08-17T00:00:01+00:00",
+        paper_id="paper-b",
+        run_id="attempt0-paper-b",
+        score=0.4,
+    )
+    _write_result(
+        records,
+        group_id="1.0",
+        timestamp="2026-08-17T00:01:00+00:00",
+        paper_id="paper-a",
+        run_id="attempt1-paper-a",
+        score=0.8,
+    )
+    _write_result(
+        records,
+        group_id="1.0",
+        timestamp="2026-08-17T00:01:01+00:00",
+        paper_id="paper-b",
+        run_id="attempt1-paper-b",
+        score=1.0,
+    )
+
+    runs = parse_run_data(tmp_path)["agent"]
+
+    assert [run.seed for run in runs] == [
+        ("2026_run-group_agent", 1),
+        ("2026_run-group_agent", 0),
+    ]
+    assert all(set(run.paper_evaluations) == {"paper-a", "paper-b"} for run in runs)
+    assert compute_agg_stats(runs, expected_papers=2).n_runs == 2

--- a/project/paperbench/tests/unit/test_metrics.py
+++ b/project/paperbench/tests/unit/test_metrics.py
@@ -3,6 +3,7 @@ from typing import Any, cast
 from paperbench.metrics import (
     PaperEvaluation,
     RunGroupRecords,
+    _attempt_id_from_recorder_group_id,
     _build_evaluation_runs,
 )
 
@@ -50,3 +51,35 @@ def test_seed_limit_applies_to_whole_run_groups() -> None:
     assert len(runs) == 1
     assert runs[0].seed == "run_B"
     assert set(runs[0].paper_evaluations) == {"paper-a"}
+
+
+def test_recorder_group_id_preserves_attempt_and_ignores_retry() -> None:
+    assert _attempt_id_from_recorder_group_id("0.0") == 0
+    assert _attempt_id_from_recorder_group_id("2.3") == 2
+    assert _attempt_id_from_recorder_group_id(None) is None
+    assert _attempt_id_from_recorder_group_id("legacy") is None
+
+
+def test_attempts_within_one_run_group_remain_distinct() -> None:
+    attempt_zero = RunGroupRecords(
+        timestamp=100.0,
+        paper_evaluations={
+            "paper-a": (_paper("a0-a", "paper-a"), 100.0),
+            "paper-b": (_paper("a0-b", "paper-b"), 101.0),
+        },
+    )
+    attempt_one = RunGroupRecords(
+        timestamp=200.0,
+        paper_evaluations={
+            "paper-a": (_paper("a1-a", "paper-a"), 200.0),
+            "paper-b": (_paper("a1-b", "paper-b"), 201.0),
+        },
+    )
+
+    runs = _build_evaluation_runs(
+        {("run_A", 0): attempt_zero, ("run_A", 1): attempt_one},
+        seeds_to_keep=None,
+    )
+
+    assert [run.seed for run in runs] == [("run_A", 1), ("run_A", 0)]
+    assert all(set(run.paper_evaluations) == {"paper-a", "paper-b"} for run in runs)

--- a/project/paperbench/tests/unit/test_metrics.py
+++ b/project/paperbench/tests/unit/test_metrics.py
@@ -1,0 +1,52 @@
+from typing import Any, cast
+
+from paperbench.metrics import (
+    PaperEvaluation,
+    RunGroupRecords,
+    _build_evaluation_runs,
+)
+
+
+def _paper(run_id: str, paper_id: str) -> PaperEvaluation:
+    return PaperEvaluation(
+        paper_run_id=run_id,
+        paper_id=paper_id,
+        graded_task_node=cast(Any, object()),
+    )
+
+
+def test_evaluation_runs_preserve_actual_run_group_boundaries() -> None:
+    newest = RunGroupRecords(
+        timestamp=200.0,
+        paper_evaluations={"paper-a": (_paper("b-a", "paper-a"), 200.0)},
+    )
+    older = RunGroupRecords(
+        timestamp=100.0,
+        paper_evaluations={
+            "paper-a": (_paper("a-a", "paper-a"), 100.0),
+            "paper-b": (_paper("a-b", "paper-b"), 101.0),
+        },
+    )
+
+    runs = _build_evaluation_runs({"run_B": newest, "run_A": older}, seeds_to_keep=None)
+
+    assert [run.seed for run in runs] == ["run_B", "run_A"]
+    assert set(runs[0].paper_evaluations) == {"paper-a"}
+    assert set(runs[1].paper_evaluations) == {"paper-a", "paper-b"}
+
+
+def test_seed_limit_applies_to_whole_run_groups() -> None:
+    newest = RunGroupRecords(
+        timestamp=200.0,
+        paper_evaluations={"paper-a": (_paper("b-a", "paper-a"), 200.0)},
+    )
+    older = RunGroupRecords(
+        timestamp=100.0,
+        paper_evaluations={"paper-b": (_paper("a-b", "paper-b"), 100.0)},
+    )
+
+    runs = _build_evaluation_runs({"run_B": newest, "run_A": older}, seeds_to_keep=1)
+
+    assert len(runs) == 1
+    assert runs[0].seed == "run_B"
+    assert set(runs[0].paper_evaluations) == {"paper-a"}

--- a/project/paperbench/tests/unit/test_recorder_context.py
+++ b/project/paperbench/tests/unit/test_recorder_context.py
@@ -1,0 +1,21 @@
+from nanoeval.json_recorder import JsonRecorder
+from nanoeval.recorder_protocol import BasicRunSpec
+from paperbench.nano.logging import PaperBenchLibraryConfig
+
+
+def test_paperbench_recorder_context_sets_attempt_group_id(tmp_path) -> None:
+    recorder = JsonRecorder(
+        run_spec=BasicRunSpec(run_id="run", run_set_id="run-set"),
+        filename=tmp_path / "results.jsonl",
+    )
+    config = PaperBenchLibraryConfig()
+
+    assert recorder.current_sample_id() is None
+    assert recorder.current_group_id() is None
+
+    with config.set_recorder_context(recorder, sample_id="paper-run", group_id="2.3"):
+        assert recorder.current_sample_id() == "paper-run"
+        assert recorder.current_group_id() == "2.3"
+
+    assert recorder.current_sample_id() is None
+    assert recorder.current_group_id() is None


### PR DESCRIPTION
## Summary

Keep PaperBench paper results grouped by the actual nanoeval run identity instead of aligning each paper independently by recency rank.

The previous parser sorted runs separately for every paper and then combined entries at the same list index into one synthetic seed. If a newer run was missing a paper, that paper could be pulled from an older run, mixing two real evaluation runs and potentially making an incomplete run appear complete. Grouping only by `run_group_id` also collapses distinct `n_tries` attempts because nanoeval places every attempt from one evaluation under the same run group.

Fixes #140.
Fixes #149.

## Fix

- retain `run_group_id` in parsed entries;
- recover the nanoeval attempt identity from recorder `group_id=<attempt_id>.<retry_idx>`;
- collect paper evaluations under `(run_group_id, attempt_id)` when attempt metadata is available;
- keep legacy records without recorder attempt metadata grouped by `run_group_id`;
- keep the latest duplicate/retry record for a paper within the same attempt;
- rank whole attempts by their latest timestamp when applying `seeds_to_keep`;
- represent missing papers as an incomplete run instead of borrowing a paper from another run.

## Regression coverage

Adds deterministic coverage for incomplete newer runs, whole-run `seeds_to_keep`, nanoeval attempt/retry identity parsing, and multiple attempts sharing the same `run_group_id`. Distinct attempts remain separate `EvaluationRun` objects instead of overwriting one another.

Scoring, disqualification handling, per-paper scores, and aggregate-stat formulas are unchanged.