### PR TITLE
Treat invalid SWE-Lancer pytest runs as rollout errors

### DIFF
--- a/project/swelancer/swelancer/eval.py
+++ b/project/swelancer/swelancer/eval.py
@@ -357,7 +357,7 @@ class SWELancerTask(ComputerTask):
                 test_results.append(-1.0)
             else:
                 test_results.append(0.0)
-        if not test_results:
+        if not any(result in (0.0, 1.0) for result in test_results):
             raise RolloutSystemError(
                 f"No tests properly ran for {self.question_id}; matching_folder: {matching_folder}"
             )


### PR DESCRIPTION
## Summary

- require at least one real pytest pass/fail result before scoring an IC SWE-Lancer task
- treat a retry set containing only the `-1.0` missing-status sentinel as a grading/infrastructure failure
- preserve ordinary failing test runs (`0.0`) as valid model failures

Previously, repeated missing `pytest_exit_code` values left `test_results` non-empty, so the evaluator returned `score=0.0` and reported that tests ran smoothly. The validity check now accepts only run sets containing at least one real pass/fail status.

The code change is intentionally limited to the existing post-retry guard.

Fixes #151.