### PR TITLE
Fix multi-answer MCQ consensus group collisions

### DIFF
--- a/project/common/nanoeval/nanoeval/solvers/mcq.py
+++ b/project/common/nanoeval/nanoeval/solvers/mcq.py
@@ -193,9 +193,9 @@ class MCQEval(ABC, Eval[MCQTask, Answer]):
 
         def _choice_to_answer_group(picked: int | set[int]) -> int:
             if isinstance(picked, set):
-                assert all(p < 10 for p in picked)
-                # Every answer group is a unique power of 10
-                return sum([10 ** (i + 1) + p for i, p in enumerate(picked)])
+                assert all(0 <= p < 10 for p in picked)
+                # Encode each selected index in its own decimal digit position.
+                return sum(10**p for p in picked)
             return picked
 
         samples_df = pd.DataFrame(


### PR DESCRIPTION
## Summary

- make multi-answer MCQ consensus group IDs uniquely represent the selected answer set
- prevent distinct answer sets with the same cardinality and index sum from being merged
- preserve the existing single-answer grouping behavior and the current `< 10` answer-index constraint

`MCQEval.get_summary()` currently encodes a set using a fixed set of powers of ten plus the sum of the selected indices. As a result, distinct sets can collide. For example, `{0, 3}` and `{1, 2}` both receive the same group ID even though they are different answers.

The new encoding places each selected index in its own decimal digit position, so distinct sets produce distinct group IDs. This keeps consensus and answer-group correctness calculations from combining different multi-answer responses.

The change is limited to the internal multi-answer group encoding.