### PR TITLE
Fix EVMbench medium findings subdirectory option

### DIFF
--- a/project/evmbench/evmbench/nano/eval.py
+++ b/project/evmbench/evmbench/nano/eval.py
@@ -43,7 +43,7 @@ class EVMbench(PythonCodingEval):
     remove_forge_artifacts: bool = chz.field(default=True)
     log_to_run_dir: bool = chz.field(default=False)
     hint_level: Literal["none", "low", "med", "high", "max"] = chz.field(default="none")
-    findings_subdir: Literal["", "low", "med", "high"] = chz.field(default="", doc="Incorrectness level for experiments")
+    findings_subdir: Literal["", "low", "medium", "high"] = chz.field(default="", doc="Incorrectness level for experiments")
     codex_auth_path: str | None = chz.field(default=None)
     use_sidecar: bool = chz.field(default=True, doc="Run ploit/veto in a sidecar for agent.")
 


### PR DESCRIPTION
## Summary

- align the EVMbench `findings_subdir` option with the audit-layer spelling
- expose `medium` rather than `med` for the medium incorrectness dataset
- leave the separate `hint_level="med"` option unchanged

The eval currently declares `findings_subdir` as `"med"`, while `Audit`, `Vulnerability`, `AuditRegistry`, and the gold-audit utility all use `"medium"`. Passing the eval's advertised medium value downstream therefore selects the wrong findings subdirectory.

This one-line change makes the eval configuration use the same `"medium"` convention as the rest of EVMbench.