### PR TITLE
Tighten compatibility Docker registry validation

### DIFF
--- a/project/common/compatibility_api/compatibility_api/task.py
+++ b/project/common/compatibility_api/compatibility_api/task.py
@@ -49,7 +49,7 @@ class CompatibleComputerTask(ComputerTask, ABC):
         # Requirements for CR sharing
         assert (
             self.docker_image
-            and self.docker_image.startswith("docker.io")
+            and self.docker_image.startswith("docker.io/")
             or self.docker_image == "jupyter/base-notebook:3.11"
         ), "Image must be specified and use a shared CR"
 


### PR DESCRIPTION
## Summary

- require Docker Hub images to use the `docker.io/` registry boundary
- reject lookalike hostnames such as `docker.io.example.com/...`
- preserve the existing `jupyter/base-notebook:3.11` compatibility exception

`CompatibleComputerTask` currently checks `docker_image.startswith("docker.io")`. That also accepts unrelated registries whose hostname merely begins with those characters, despite the validator requiring a shared container registry.

This changes the prefix check to `docker.io/`, so only actual Docker Hub-qualified image references satisfy that branch of the compatibility constraint.

The change is intentionally limited to the existing image-registry validation.