### PR TITLE
Use configured EVMbench incorrect finding text

### DIFF
--- a/project/evmbench/evmbench/audit.py
+++ b/project/evmbench/evmbench/audit.py
@@ -53,6 +53,8 @@ class Vulnerability:
     @property
     def text_content(self) -> str:
         findings_path = get_audits_dir() / self.audit_id / "findings"
+        if self.findings_subdir:
+            findings_path = findings_path / "incorrect" / self.findings_subdir
         return (findings_path / f"{self.id}.md").read_text()
 
 @dataclass(frozen=True)

--- a/project/evmbench/tests/test_incorrect_finding_content.py
+++ b/project/evmbench/tests/test_incorrect_finding_content.py
@@ -1,0 +1,26 @@
+import evmbench.audit as audit_module
+from evmbench.audit import Vulnerability
+
+
+def test_vulnerability_text_content_uses_configured_incorrect_findings(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setattr(audit_module, "get_audits_dir", lambda: tmp_path)
+
+    findings_dir = tmp_path / "sample-audit" / "findings"
+    incorrect_dir = findings_dir / "incorrect" / "medium"
+    incorrect_dir.mkdir(parents=True)
+
+    (findings_dir / "H-01.md").write_text("canonical finding")
+    (incorrect_dir / "H-01.md").write_text("medium incorrect finding")
+
+    canonical = Vulnerability(id="H-01", audit_id="sample-audit", title="Finding")
+    incorrect = Vulnerability(
+        id="H-01",
+        audit_id="sample-audit",
+        title="Finding",
+        findings_subdir="medium",
+    )
+
+    assert canonical.text_content == "canonical finding"
+    assert incorrect.text_content == "medium incorrect finding"


### PR DESCRIPTION
## Summary

- make `Vulnerability.text_content` honor `findings_subdir`
- load experimental finding text from `findings/incorrect/<level>/<id>.md`
- preserve canonical `findings/<id>.md` behavior when no incorrectness level is selected

EVMbench already propagates `findings_subdir` from `AuditRegistry` into each `Vulnerability`, and gold-audit generation uses the corresponding incorrect-findings directory. The detect grader, however, reads `vulnerability.text_content`, which currently always returns the canonical finding.

That means incorrectness experiments can present modified findings while the judge still compares the model report against the canonical vulnerability description.

The regression verifies both canonical and `medium` incorrect finding selection.