### PR TITLE
Normalize EVMbench scores at the nanoeval boundary

### DIFF
--- a/project/evmbench/evmbench/nano/grade/base.py
+++ b/project/evmbench/evmbench/nano/grade/base.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
-from pydantic import BaseModel, Field
-from typing import Any, Literal
+from pydantic import BaseModel, Field, model_validator
+from typing import Any, Literal, Self
 
 import structlog.stdlib
 from nanoeval.solvers.computer_tasks.task import Grade
@@ -57,6 +57,17 @@ class EVMbenchDetectResult(EVMbenchResult):
 class EVMbenchGrade(Grade):
     """Wrapper class for interfacting with nanoeval."""
     evmbench_result: EVMbenchResult
+
+    @model_validator(mode="after")
+    def normalize_nanoeval_score(self) -> Self:
+        max_score = float(self.evmbench_result.max_score)
+        self.score = (
+            float(self.evmbench_result.score) / max_score
+            if max_score > 0
+            else 0.0
+        )
+        self.is_continuous = True
+        return self
 
 class GraderContext(BaseModel):
     audit: Audit

--- a/project/evmbench/tests/test_nanoeval_grade_score.py
+++ b/project/evmbench/tests/test_nanoeval_grade_score.py
@@ -1,0 +1,35 @@
+from nanoeval.solvers.computer_tasks.steps import FinalResult
+
+from evmbench.nano.grade.base import EVMbenchGrade, EVMbenchResult
+
+
+def _grade(score: float, max_score: float) -> EVMbenchGrade:
+    return EVMbenchGrade(
+        score=score,
+        grader_log="",
+        evmbench_result=EVMbenchResult(
+            audit_id="sample-audit",
+            score=score,
+            max_score=max_score,
+        ),
+    )
+
+
+def test_evmbench_grade_normalizes_score_for_nanoeval_correctness() -> None:
+    perfect = _grade(4, 4)
+    partial = _grade(2, 4)
+
+    assert perfect.score == 1.0
+    assert perfect.evmbench_result.score == 4
+    assert FinalResult(grade=perfect).correct is True
+
+    assert partial.score == 0.5
+    assert partial.evmbench_result.score == 2
+    assert FinalResult(grade=partial).correct is False
+
+
+def test_evmbench_grade_handles_zero_max_score() -> None:
+    grade = _grade(0, 0)
+
+    assert grade.score == 0.0
+    assert grade.is_continuous is True


### PR DESCRIPTION
## Summary

- normalize `EVMbenchGrade.score` to `score / max_score`
- keep raw EVMbench score and max score unchanged in `evmbench_result`
- mark the wrapper grade continuous and handle zero-max-score results safely

Nanoeval defines `FinalResult.correct` as `grade.score == 1`. EVMbench currently puts its raw count/point score in that wrapper field, so a perfect result such as `4/4` is treated as incorrect because `4 != 1`.

The raw benchmark metrics already live in `evmbench_result.score` and `evmbench_result.max_score`. Normalizing only the nanoeval wrapper preserves those values while restoring the intended generic correctness behavior for logging and progress reporting.

Regression coverage checks perfect, partial, and zero-max-score cases.