### PR TITLE
Reject zero nanoeval multiprocessing workers

### DIFF
--- a/project/common/nanoeval/nanoeval/eval.py
+++ b/project/common/nanoeval/nanoeval/eval.py
@@ -250,7 +250,7 @@ class RunnerArgs:
 
     @chz.validate
     def _validate_multiprocessing_options(self) -> None:
-        if self.num_processes:
+        if self.num_processes is not None:
             assert self.num_processes > 0
             assert self.experimental_use_multiprocessing, (
                 "num_processes requires experimental_use_multiprocessing"

--- a/project/common/nanoeval/nanoeval/eval_test.py
+++ b/project/common/nanoeval/nanoeval/eval_test.py
@@ -1,0 +1,11 @@
+import pytest
+
+from nanoeval.eval import RunnerArgs
+
+
+def test_runner_args_reject_zero_num_processes() -> None:
+    with pytest.raises(AssertionError):
+        RunnerArgs(
+            experimental_use_multiprocessing=True,
+            num_processes=0,
+        )


### PR DESCRIPTION
## Summary

- reject `RunnerArgs(num_processes=0)` during configuration validation
- keep `None` as the default automatic worker-count mode
- preserve the existing requirement that an explicit worker count enables multiprocessing

`_validate_multiprocessing_options()` currently checks `if self.num_processes`, so zero skips both validation checks. The value can then reach the multiprocessing executor even though an explicit process count must be positive.

The fix distinguishes `None` from an explicit integer and validates zero the same way as any other non-positive worker count.

Regression coverage verifies that zero is rejected.