### PR TITLE
Fix PaperBench rubric pruning at subtree boundaries

### DIFF
--- a/project/paperbench/paperbench/rubric/tasks.py
+++ b/project/paperbench/paperbench/rubric/tasks.py
@@ -312,7 +312,7 @@ class TaskNode:
                 requirements=self.requirements,
                 weight=self.weight,
                 sub_tasks=[],
-                task_category=self.task_category,
+                task_category=self.task_category or "Subtree",
                 finegrained_task_category=self.finegrained_task_category,
             )
 

--- a/project/paperbench/tests/unit/test_rubric_tasks.py
+++ b/project/paperbench/tests/unit/test_rubric_tasks.py
@@ -1,0 +1,24 @@
+from paperbench.rubric.tasks import TaskNode
+
+
+def test_prune_to_depth_marks_collapsed_internal_node_as_subtree() -> None:
+    leaf = TaskNode(
+        id="leaf",
+        requirements="leaf requirement",
+        weight=1,
+        task_category="Code Development",
+    )
+    root = TaskNode(
+        id="root",
+        requirements="root requirement",
+        weight=1,
+        sub_tasks=[leaf],
+    )
+
+    pruned = root.prune_to_depth(0)
+
+    assert pruned.is_leaf()
+    assert pruned.task_category == "Subtree"
+    assert pruned.id == root.id
+    assert pruned.requirements == root.requirements
+    assert pruned.weight == root.weight


### PR DESCRIPTION
## Summary

- assign the existing `Subtree` task category when pruning an internal rubric node into a leaf
- preserve the original task category when the pruned node is already a leaf
- keep rubric IDs, requirements, weights, and fine-grained categories unchanged

`TaskNode` requires every leaf to have a task category and every internal node to have no task category. `prune_to_depth()` currently copies `self.task_category` when replacing a node with a leaf. For an internal node that value is necessarily `None`, so pruning at the requested depth raises `ValueError` instead of producing a pruned tree.

`Subtree` is already a supported category used for approximate subtree grading, so it is the natural category for a collapsed internal node.

Regression coverage prunes an internal root at depth zero and verifies it becomes a valid `Subtree` leaf.