### PR TITLE
Handle empty EVMbench summaries

### DIFF
--- a/project/evmbench/evmbench/nano/eval.py
+++ b/project/evmbench/evmbench/nano/eval.py
@@ -181,7 +181,6 @@ class EVMbench(PythonCodingEval):
     ) -> dict[str, Any]:
         ctx_logger = logger.bind(run_group_id=self.run_group_id, runs_dir=self.runs_dir)
 
-        tasks = [t for t, _ in results]
         final_results = [
             r.grade.evmbench_result
             for _, r in results
@@ -240,7 +239,7 @@ class EVMbench(PythonCodingEval):
             "params": params,
             "run_health": run_health,
             "metrics": metrics,
-            "run_group_id": getattr(tasks[0], "run_group_id", "undefined"),
+            "run_group_id": self.run_group_id,
         }
 
         ctx_logger.info(

--- a/project/evmbench/tests/test_empty_summary.py
+++ b/project/evmbench/tests/test_empty_summary.py
@@ -1,0 +1,15 @@
+import pytest
+
+from evmbench.nano.eval import EVMbench
+
+
+@pytest.mark.asyncio
+async def test_evmbench_full_summary_handles_empty_results() -> None:
+    eval = EVMbench()
+
+    summary = await eval.get_full_summary([])
+
+    assert summary["params"]["n_samples"] == 0
+    assert summary["metrics"]["score"] == 0
+    assert summary["metrics"]["max_score"] == 0
+    assert summary["run_group_id"] == eval.run_group_id


### PR DESCRIPTION
## Summary

- make `EVMbench.get_full_summary()` handle an empty result set
- use the eval's own `run_group_id` rather than indexing the first result task
- preserve existing score, health, and per-audit aggregation behavior

Nanoeval's base `Eval.self_test()` explicitly calls `get_full_summary([])`. EVMbench currently builds a task list and then reads `tasks[0]` solely to populate the run-group ID, which raises `IndexError` when no results are available.

The eval already owns the canonical `run_group_id`, so the summary can use that value directly without depending on a completed task.

Regression coverage verifies an empty summary reports zero samples and scores while retaining the eval run-group ID.