### PR TITLE
Group binary agent outcomes for standard metrics

### DIFF
--- a/project/common/nanoeval/nanoeval/metrics/agents.py
+++ b/project/common/nanoeval/nanoeval/metrics/agents.py
@@ -13,10 +13,13 @@ def _compute_metrics_plus_outcome_aggregations(samples_df: pd.DataFrame) -> dict
     Compute standard metrics and aggregations for a given DataFrame of samples.
     """
 
-    # Get answer_group_id on samples_df
-    samples_df["answer_group_id"] = samples_df.groupby("instance").cumcount()
-    answer_group_correctness_df = samples_df[["instance", "attempt", "answer_group_id"]]
-    answer_group_correctness_df["is_correct"] = samples_df["correct"]
+    # Binary agent outcomes have two answer groups: incorrect and correct.
+    samples_df["answer_group_id"] = samples_df["correct"].astype(int)
+    answer_group_correctness_df = (
+        samples_df[["instance", "answer_group_id", "correct"]]
+        .drop_duplicates(subset=["instance", "answer_group_id"])
+        .rename(columns={"correct": "is_correct"})
+    )
 
     metrics: dict[str, Any] = {
         **compute_default_metrics(samples_df, answer_group_correctness_df),

--- a/project/common/nanoeval/nanoeval/metrics/agents_test.py
+++ b/project/common/nanoeval/nanoeval/metrics/agents_test.py
@@ -1,0 +1,36 @@
+import pandas as pd
+
+import nanoeval.metrics.agents as agents
+
+
+def test_binary_agent_outcomes_share_answer_groups(monkeypatch) -> None:
+    captured: dict[str, pd.DataFrame] = {}
+
+    def capture_metrics(
+        samples_df: pd.DataFrame, answer_group_correctness_df: pd.DataFrame
+    ) -> dict[str, float]:
+        captured["samples"] = samples_df.copy()
+        captured["correctness"] = answer_group_correctness_df.copy()
+        return {"accuracy": 2 / 3}
+
+    monkeypatch.setattr(agents, "compute_default_metrics", capture_metrics)
+
+    samples = pd.DataFrame(
+        {
+            "instance": ["q", "q", "q"],
+            "attempt": [0, 1, 2],
+            "correct": [True, True, False],
+            "system_error": [False, False, False],
+            "error": [None, None, None],
+        }
+    )
+
+    summary = agents._compute_metrics_plus_outcome_aggregations(samples)
+
+    assert captured["samples"]["answer_group_id"].tolist() == [1, 1, 0]
+    assert captured["correctness"].to_dict("records") == [
+        {"instance": "q", "answer_group_id": 1, "is_correct": True},
+        {"instance": "q", "answer_group_id": 0, "is_correct": False},
+    ]
+    assert summary["aggregations"]["num_correct"] == 2
+    assert summary["aggregations"]["num_incorrect"] == 1


### PR DESCRIPTION
## Summary

- group agent-summary answers by their binary correctness outcome instead of assigning every rollout a unique answer group
- deduplicate the per-instance correctness mapping for the two binary groups
- preserve existing outcome counts and system-error handling

`get_summary_error_aware()` only has a binary result for each rollout: correct or incorrect. `_compute_metrics_plus_outcome_aggregations()` currently assigns `answer_group_id` with `groupby(...).cumcount()`, so every attempt is treated as a different answer even when multiple attempts have the same outcome.

That does not affect the repository's minimal accuracy-only backend, but it breaks the answer-group contract for richer standard metric backends that use group identity for consensus-style metrics. Two correct attempts should belong to the same answer group, as should two incorrect attempts.

The fix uses `1` for correct and `0` for incorrect, and keeps one correctness row per `(instance, answer_group_id)` so repeated outcomes do not duplicate the correctness mapping.

Regression coverage verifies that repeated correct attempts share one group while incorrect attempts use the other group.