### PR TITLE
Preserve nanoeval max concurrency when resuming run sets

### DIFF
--- a/project/common/nanoeval/nanoeval/_db.py
+++ b/project/common/nanoeval/nanoeval/_db.py
@@ -136,9 +136,9 @@ async def open_run_set_db(
                 """
                 INSERT INTO metadata (key, value)
                 VALUES (?, ?)
-                ON CONFLICT(key) DO UPDATE SET value = ?
+                ON CONFLICT(key) DO NOTHING
                 """,
-                ("max_concurrency", _INITIAL_MAX_CONCURRENCY, _INITIAL_MAX_CONCURRENCY),
+                ("max_concurrency", _INITIAL_MAX_CONCURRENCY),
             )
             conn.commit()
 

--- a/project/common/nanoeval/nanoeval/_db_test.py
+++ b/project/common/nanoeval/nanoeval/_db_test.py
@@ -1,0 +1,26 @@
+from uuid import uuid4
+
+import pytest
+
+from nanoeval._db import open_run_set_db
+
+
+@pytest.mark.asyncio
+async def test_reopening_run_set_preserves_max_concurrency() -> None:
+    run_set_id = f"test-{uuid4()}"
+
+    async with open_run_set_db(backup=False, run_set_id=run_set_id) as db:
+        with db.conn() as conn:
+            conn.execute(
+                "UPDATE metadata SET value = ? WHERE key = 'max_concurrency'",
+                (7,),
+            )
+            conn.commit()
+
+    async with open_run_set_db(backup=False, run_set_id=run_set_id) as db:
+        with db.conn() as conn:
+            value = conn.execute(
+                "SELECT value FROM metadata WHERE key = 'max_concurrency'"
+            ).fetchone()[0]
+
+    assert int(value) == 7


### PR DESCRIPTION
## Summary

- preserve an existing run set's stored `max_concurrency` when the database is reopened
- initialize the default limit only when the metadata key does not yet exist
- keep the existing `run_set_id` metadata behavior unchanged

`open_run_set_db()` currently upserts `max_concurrency` with `ON CONFLICT ... DO UPDATE`, resetting it to `1_000_000` every time an existing run-set database is opened.

This conflicts directly with `nanoeval.bin.concurrency`, which stores a user-selected limit in the same metadata key. Reopening or resuming the run set therefore silently discards that value before workers read it, and even the concurrency command itself resets the previous value as part of opening the database.

The fix changes initialization to `ON CONFLICT DO NOTHING`, so new databases still receive the default while existing run sets retain their configured limit.

Regression coverage sets a custom limit, closes the run set, reopens the same run-set ID, and verifies the value is preserved.