### PR TITLE
Fix PaperBench zero prior-node limit

### DIFF
--- a/project/paperbench/paperbench/rubric/tasks.py
+++ b/project/paperbench/paperbench/rubric/tasks.py
@@ -270,7 +270,7 @@ class TaskNode:
 
         required_nodes = required_nodes[:-1]  # Don't include the target node
         if max_prior_nodes is not None:
-            required_nodes = required_nodes[-max_prior_nodes:]
+            required_nodes = required_nodes[-max_prior_nodes:] if max_prior_nodes > 0 else []
         return required_nodes
 
     def get_descendants_depth_first(self) -> list[Self]:

--- a/project/paperbench/tests/unit/test_rubric_prior_nodes.py
+++ b/project/paperbench/tests/unit/test_rubric_prior_nodes.py
@@ -1,0 +1,33 @@
+from paperbench.rubric.tasks import TaskNode
+
+
+def _rubric() -> tuple[TaskNode, TaskNode]:
+    b = TaskNode(
+        id="B",
+        requirements="B",
+        weight=1,
+        task_category="Code Development",
+    )
+    f = TaskNode(
+        id="F",
+        requirements="F",
+        weight=1,
+        task_category="Code Development",
+    )
+    g = TaskNode(
+        id="G",
+        requirements="G",
+        weight=1,
+        task_category="Code Development",
+    )
+    c = TaskNode(id="C", requirements="C", weight=1, sub_tasks=[f, g])
+    root = TaskNode(id="A", requirements="A", weight=1, sub_tasks=[b, c])
+    return root, g
+
+
+def test_get_prior_nodes_respects_zero_limit() -> None:
+    root, target = _rubric()
+
+    assert [node.id for node in target.get_prior_nodes(root)] == ["A", "B", "C", "F"]
+    assert target.get_prior_nodes(root, max_prior_nodes=0) == []
+    assert [node.id for node in target.get_prior_nodes(root, max_prior_nodes=2)] == ["C", "F"]


### PR DESCRIPTION
## Summary

- make `max_prior_nodes=0` return no prior rubric nodes
- preserve the existing unlimited behavior when the limit is `None`
- preserve positive limits as a tail slice of the available prior context

`TaskNode.get_prior_nodes()` currently applies `required_nodes[-max_prior_nodes:]` whenever a limit is provided. In Python, `-0` is `0`, so `[-0:]` is the same as `[0:]`. Explicitly requesting zero prior nodes therefore returns every prior node instead of none.

This can inject all available prior rubric context into `SimpleJudge` when a caller intentionally configures a zero-node context budget.

The fix handles zero explicitly while leaving positive and unlimited behavior unchanged.

Regression coverage verifies unlimited, zero, and positive-limit cases.