### PR TITLE
Apply default nanoeval recorder sample context

### DIFF
--- a/project/common/nanoeval/nanoeval/library_config.py
+++ b/project/common/nanoeval/nanoeval/library_config.py
@@ -203,7 +203,8 @@ class LibraryConfig:
     def set_recorder_context(
         self, rec: RecorderProtocol, sample_id: str, group_id: str
     ) -> Generator[None, None, None]:
-        yield
+        with rec.as_default_recorder(sample_id, group_id):
+            yield
 
     def get_dummy_recorder(self, log: bool) -> RecorderConfig:
         return _DummyRecorderConfig()

--- a/project/common/nanoeval/nanoeval/library_config_test.py
+++ b/project/common/nanoeval/nanoeval/library_config_test.py
@@ -1,0 +1,34 @@
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+from nanoeval.library_config import LibraryConfig, get_library_config, set_library_config
+from nanoeval.recorder import set_default_recorder
+
+
+class ContextRecorder:
+    def __init__(self) -> None:
+        self.context: tuple[str, str | None] | None = None
+
+    @contextmanager
+    def as_default_recorder(
+        self, sample_id: str, group_id: str | None = None
+    ) -> Iterator[None]:
+        self.context = (sample_id, group_id)
+        try:
+            yield
+        finally:
+            self.context = None
+
+
+def test_default_library_config_applies_recorder_sample_context() -> None:
+    original_config = get_library_config()
+    recorder: Any = ContextRecorder()
+    set_library_config(LibraryConfig())
+
+    try:
+        with set_default_recorder(recorder, sample_id="sample", group_id="group"):
+            assert recorder.context == ("sample", "group")
+    finally:
+        set_library_config(original_config)
+
+    assert recorder.context is None


### PR DESCRIPTION
## Summary

- make the default `LibraryConfig.set_recorder_context()` delegate to the recorder's `as_default_recorder()` context manager
- ensure the default JSON recorder receives the sample and group IDs supplied by `set_default_recorder()`
- leave custom `LibraryConfig` overrides unchanged

Nanoeval's normal execution path calls `set_default_recorder(recorder, sample_id=..., group_id=...)`, which in turn delegates sample scoping to `LibraryConfig.set_recorder_context()`. The default hook is currently a no-op, even though `RecorderProtocol` defines `as_default_recorder()` and the default `JsonRecorder` uses that context to populate `sample_id` and `group_id` on emitted records.

As a result, the default recorder can write records without the sample/group identity that the executor supplied.

The fix makes the default library hook use the recorder's own context manager. Custom library configurations can still override the hook as before.

Regression coverage exercises the normal `set_default_recorder()` path and verifies that recorder context is applied and cleaned up.