### PR TITLE
Honor zero-hour PaperBench checkpoint selection

### DIFF
--- a/project/paperbench/paperbench/nano/task.py
+++ b/project/paperbench/paperbench/nano/task.py
@@ -400,7 +400,9 @@ class PBTask(ComputerTask):
             return None
 
         # Get the submission at the target duration if it is set, otherwise get the latest submission
-        target_duration_hr = self.target_duration_hr if self.target_duration_hr else 10000
+        target_duration_hr = (
+            self.target_duration_hr if self.target_duration_hr is not None else 10000
+        )
         checkpoint = get_file_at_duration(submission_checkpoints, target_duration_hr)
 
         path, duration = checkpoint["path"], checkpoint["duration"]

--- a/project/paperbench/tests/unit/test_checkpoint_selection.py
+++ b/project/paperbench/tests/unit/test_checkpoint_selection.py
@@ -1,0 +1,20 @@
+from datetime import timedelta
+
+import pytest
+
+from paperbench.nano.task import PBTask
+
+
+@pytest.mark.asyncio
+async def test_zero_target_duration_selects_earliest_checkpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    checkpoints = [
+        "/runs/task/submissions/2026-01-01T02-00-00-GMT/submission.tar.gz",
+        "/runs/task/submissions/2026-01-01T00-00-00-GMT/submission.tar.gz",
+        "/runs/task/submissions/2026-01-01T01-00-00-GMT/submission.tar.gz",
+    ]
+    task = PBTask.model_construct(run_dir="/runs/task", target_duration_hr=0)
+    monkeypatch.setattr("paperbench.nano.task.bf.glob", lambda _pattern: checkpoints)
+
+    checkpoint = await task._select_checkpoint()
+
+    assert checkpoint == (checkpoints[1], timedelta(0))


### PR DESCRIPTION
## Summary

- preserve `target_duration_hr=0` as a valid PaperBench checkpoint target
- keep `None` as the sentinel for selecting the latest available checkpoint
- add regression coverage showing that a zero-hour target selects the earliest submission

`PBTask._select_checkpoint()` currently uses a truthiness check when choosing the duration passed to `get_file_at_duration()`. Because `0` is falsey, an explicit `target_duration_hr=0` is replaced with `10000`, which selects the latest checkpoint instead of the checkpoint at the start of the run.

The configuration type and `get_file_at_duration()` both support zero as a valid non-negative duration. This change switches the fallback check to `is not None`, so zero keeps its documented meaning while the existing `None` behavior remains unchanged.