### PR TITLE
Fix SWE-Lancer default runs directory

### DIFF
--- a/project/swelancer/swelancer/utils/custom_logging.py
+++ b/project/swelancer/swelancer/utils/custom_logging.py
@@ -1,5 +1,4 @@
 import time
-from pathlib import Path
 
 import blobfile as bf
 import structlog
@@ -8,6 +7,7 @@ from typing_extensions import override
 
 from nanoeval.library_config import LibraryConfig, set_library_config
 from nanoeval.setup import nanoeval_logging
+from swelancer.utils.general import get_runs_dir
 
 
 def get_timestamp() -> str:
@@ -17,7 +17,7 @@ def get_timestamp() -> str:
 
 
 def get_default_runs_dir() -> str:
-    return str(Path(__name__).parent / "runs")
+    return str(get_runs_dir())
 
 
 def setup_logging(library_config: LibraryConfig) -> None:

--- a/project/swelancer/tests/test_custom_logging.py
+++ b/project/swelancer/tests/test_custom_logging.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+from swelancer.utils.custom_logging import get_default_runs_dir
+from swelancer.utils.general import get_runs_dir
+
+
+def test_default_runs_dir_uses_project_runs_directory() -> None:
+    default_runs_dir = Path(get_default_runs_dir())
+
+    assert default_runs_dir == get_runs_dir()
+    assert default_runs_dir.is_absolute()


### PR DESCRIPTION
## Summary

- make SWE-Lancer's default runs directory use the existing project-root helper
- avoid constructing a relative path from the module name string
- add regression coverage that requires the default runs path to match the canonical absolute project runs directory

`get_default_runs_dir()` currently calls `Path(__name__).parent / "runs"`. Since `__name__` is a module name such as `swelancer.utils.custom_logging`, this produces a relative path like `swelancer.utils/runs` rather than the project's actual `runs/` directory.

The same helper is used as the default value for `SWELancerEval.runs_dir`, so this can place run output and fallback log output in an unintended working-directory-relative location.

This change delegates to the existing `swelancer.utils.general.get_runs_dir()` helper, which resolves the project root and returns the canonical absolute runs directory.