### PR TITLE
fix(paperbench): handle uneven seed counts in run parsing

### DIFF
--- a/project/paperbench/paperbench/metrics.py
+++ b/project/paperbench/paperbench/metrics.py
@@ -293,7 +293,7 @@ def parse_run_data(
             eval_run = EvaluationRun(seed=seed, paper_evaluations={})
             for data in filtered_paper_data.values():
                 # some evaluation runs may not have all papers evaluated
-                if seed == len(data):
+                if seed >= len(data):
                     continue
                 paper_eval = data[seed]["paper_eval"]
                 eval_run.paper_evaluations[paper_eval.paper_id] = paper_eval

--- a/project/paperbench/tests/unit/test_metrics.py
+++ b/project/paperbench/tests/unit/test_metrics.py
@@ -1,0 +1,52 @@
+import json
+
+from paperbench.metrics import parse_run_data
+
+
+def _graded_task_tree() -> dict:
+    return {
+        "id": "task",
+        "requirements": "test requirement",
+        "weight": 1,
+        "sub_tasks": [],
+        "task_category": "Code Development",
+        "score": 1.0,
+        "valid_score": True,
+        "explanation": "ok",
+    }
+
+
+def _entry(paper_id: str, run_id: str, timestamp: str) -> dict:
+    return {
+        "record_type": "extra",
+        "timestamp": timestamp,
+        "data": {
+            "run_group_id": "group_agent",
+            "run_id": run_id,
+            "pb_result": {
+                "paperbench_result": {
+                    "paper_id": paper_id,
+                    "judge_output": {"graded_task_tree": _graded_task_tree()},
+                }
+            },
+        },
+    }
+
+
+def test_parse_run_data_handles_papers_with_uneven_seed_counts(tmp_path):
+    entries = [
+        _entry("paper-a", "a-1", "2026-01-03T00:00:00Z"),
+        _entry("paper-a", "a-2", "2026-01-02T00:00:00Z"),
+        _entry("paper-a", "a-3", "2026-01-01T00:00:00Z"),
+        _entry("paper-b", "b-1", "2026-01-03T00:00:00Z"),
+    ]
+    run_file = tmp_path / "runs.jsonl"
+    run_file.write_text("".join(f"{json.dumps(entry)}\n" for entry in entries))
+
+    runs = parse_run_data(tmp_path)
+
+    assert list(runs) == ["agent"]
+    assert len(runs["agent"]) == 3
+    assert set(runs["agent"][0].paper_evaluations) == {"paper-a", "paper-b"}
+    assert set(runs["agent"][1].paper_evaluations) == {"paper-a"}
+    assert set(runs["agent"][2].paper_evaluations) == {"paper-a"}


### PR DESCRIPTION
## Summary

Make PaperBench run reconstruction handle papers with uneven numbers of recorded seeds without raising `IndexError`.

`parse_run_data()` builds seed-indexed `EvaluationRun` objects up to the largest per-paper seed count. For a paper with fewer runs, the loop currently skips only when:

```python
seed == len(data)
```

If another paper has two or more additional seeds, a later iteration reaches `seed > len(data)` and still evaluates `data[seed]`, crashing the metrics parser.

## Fix

Treat every out-of-range seed as unavailable:

```python
if seed >= len(data):
    continue
```

This preserves the intended behavior described by the surrounding comment: incomplete evaluation runs are retained with only the paper evaluations that exist for that seed.

## Regression coverage

Added a JSONL-level regression with one paper containing three recorded runs and another containing one. The test verifies that parsing produces three evaluation runs, with the shorter paper present only in the first run, instead of crashing on the third seed.

## Risk

Low. Equal-length run sets are unchanged. The only behavior change is for uneven per-paper seed counts that would otherwise index past the end of a paper's data.

## Issue number

N/A. Found while auditing PaperBench metrics reconstruction.