### PR TITLE
fix(paperbench): preserve solver shortnames in metrics parsing

### DIFF
--- a/project/paperbench/paperbench/metrics.py
+++ b/project/paperbench/paperbench/metrics.py
@@ -231,7 +231,11 @@ def parse_run_data(
 
         run_group_id = entry["data"]["run_group_id"]
         paper_run_id = entry["data"]["run_id"]
-        agent_id = run_group_id.split("_")[-1]
+        agent_id = (
+            run_group_id.rsplit("_run-group_", 1)[-1]
+            if "_run-group_" in run_group_id
+            else run_group_id.split("_")[-1]
+        )
         paper_id = pb_result["paper_id"]
         timestamp = dateutil.parser.parse(entry["timestamp"]).timestamp()
 

--- a/project/paperbench/tests/unit/test_metrics.py
+++ b/project/paperbench/tests/unit/test_metrics.py
@@ -1,0 +1,40 @@
+import json
+
+from paperbench.metrics import parse_run_data
+
+
+def test_parse_run_data_preserves_solver_shortname_with_underscores(tmp_path):
+    entry = {
+        "record_type": "extra",
+        "timestamp": "2026-01-01T00:00:00Z",
+        "data": {
+            "run_group_id": "2026-01-01T00-00-00-UTC_run-group_direct_submission_solver",
+            "run_id": "paper-a_run-1",
+            "pb_result": {
+                "paperbench_result": {
+                    "paper_id": "paper-a",
+                    "judge_output": {
+                        "graded_task_tree": {
+                            "id": "task",
+                            "requirements": "test requirement",
+                            "weight": 1,
+                            "sub_tasks": [],
+                            "task_category": "Code Development",
+                            "score": 1.0,
+                            "valid_score": True,
+                            "explanation": "ok",
+                        }
+                    },
+                }
+            },
+        },
+    }
+    run_file = tmp_path / "runs.jsonl"
+    run_file.write_text(f"{json.dumps(entry)}\n")
+
+    runs = parse_run_data(tmp_path)
+
+    assert list(runs) == ["direct_submission_solver"]
+    assert runs["direct_submission_solver"][0].paper_evaluations["paper-a"].paper_run_id == (
+        "paper-a_run-1"
+    )


### PR DESCRIPTION
## Summary

Preserve complete PaperBench solver shortnames when reconstructing agent IDs from run-group records.

PaperBench creates run-group IDs as:

```text
<timestamp>_run-group_<solver.shortname()>
```

but `parse_run_data()` currently derives the agent ID with:

```python
run_group_id.split("_")[-1]
```

That truncates any solver shortname containing underscores. The built-in direct-submission solver reports `direct_submission_solver`, so its records are currently grouped under the incorrect agent ID `solver`.

## Fix

Parse the generated `_run-group_` delimiter and preserve the full suffix as the solver/agent identifier. For records that do not contain that delimiter, retain the previous final-underscore-token fallback for compatibility with older/custom run-group IDs.

## Regression coverage

Added a JSONL-level regression using the built-in `direct_submission_solver` naming shape and verified that `parse_run_data()` returns the full `direct_submission_solver` key and retains the corresponding paper run.

## Risk

Low. Standard run groups now preserve exactly the shortname used when they were created. Legacy/custom IDs without the `_run-group_` delimiter keep the previous parsing behavior.

## Issue number

N/A. Found while auditing PaperBench metrics attribution.